### PR TITLE
Upgrade SwiftState to 2.0.0 and refactor state machine factory

### DIFF
--- a/Tokensharp.Tests/CsvTests.cs
+++ b/Tokensharp.Tests/CsvTests.cs
@@ -2,15 +2,17 @@
 
 public record CsvTokenTypes(string Identifier) : TokenType<CsvTokenTypes>(Identifier), ITokenType<CsvTokenTypes>
 {
-    public static readonly CsvTokenTypes Comma = new(",");
-    public static readonly CsvTokenTypes EndOfRecord = new("\r\n");
-    public static readonly CsvTokenTypes DoubleQuote = new("\"");
+    public static readonly CsvTokenTypes Comma = new("comma");
+    public static readonly CsvTokenTypes EndOfRecord = new("endOfRecord");
+    public static readonly CsvTokenTypes DoubleQuote = new("doubleQuote");
+    public static readonly CsvTokenTypes Escape = new("escape");
 
     public static TokenConfiguration<CsvTokenTypes> Configuration { get; } = new TokenConfigurationBuilder<CsvTokenTypes>()
     {
-        Comma,
-        EndOfRecord,
-        DoubleQuote
+        { ",", Comma },
+        { "\r\n", EndOfRecord },
+        { "\"", DoubleQuote },
+        { "\"\"", Escape }
     }.Build();
     
     public static CsvTokenTypes Create(string token) => new(token);
@@ -30,17 +32,38 @@ public class CsvTests : TokenizerTestBase<CsvTokenTypes>
         RunTest(testStr, 
         [
             new TestCase<CsvTokenTypes>(CsvTokenTypes.Text, "test"),
-            new TestCase<CsvTokenTypes>(CsvTokenTypes.Comma),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.Comma, ","),
             new TestCase<CsvTokenTypes>(CsvTokenTypes.WhiteSpace, " "),
             new TestCase<CsvTokenTypes>(CsvTokenTypes.Number, "123"),
-            new TestCase<CsvTokenTypes>(CsvTokenTypes.EndOfRecord),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.EndOfRecord, "\r\n"),
             new TestCase<CsvTokenTypes>(CsvTokenTypes.Text, "foo"),
-            new TestCase<CsvTokenTypes>(CsvTokenTypes.Comma),
-            new TestCase<CsvTokenTypes>(CsvTokenTypes.DoubleQuote),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.Comma, ","),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.DoubleQuote, "\""),
             new TestCase<CsvTokenTypes>(CsvTokenTypes.Text, "bar"),
-            new TestCase<CsvTokenTypes>(CsvTokenTypes.EndOfRecord),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.EndOfRecord, "\r\n"),
             new TestCase<CsvTokenTypes>(CsvTokenTypes.Text, "bizz"),
-            new TestCase<CsvTokenTypes>(CsvTokenTypes.DoubleQuote)
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.DoubleQuote, "\"")
+        ]);
+    }
+
+    [Test]
+    public void CsvWithEscapedQuotes()
+    {   
+        const string testStr = "123, \"\"\"Bar\"\"\" ,ABC";
+        
+        RunTest(testStr, 
+        [
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.Number, "123"),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.Comma, ","),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.WhiteSpace, " "),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.Escape, "\"\""),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.DoubleQuote, "\""),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.Text, "Bar"),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.Escape, "\"\""),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.DoubleQuote, "\""),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.WhiteSpace, " "),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.Comma, ","),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.Text, "ABC")
         ]);
     }
 }

--- a/Tokensharp.TokenTypeGenerator.Test/Tokensharp.TokenTypeGenerator.Test.csproj
+++ b/Tokensharp.TokenTypeGenerator.Test/Tokensharp.TokenTypeGenerator.Test.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Tokensharp" Version="3.0.0" />
+      <PackageReference Include="Tokensharp" Version="3.0.1" />
       <PackageReference Include="Tokensharp.TokenTypeGenerator" Version="1.0.2" />
     </ItemGroup>
 

--- a/Tokensharp/Tokensharp.csproj
+++ b/Tokensharp/Tokensharp.csproj
@@ -9,12 +9,12 @@
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>3.0.0</Version>
+        <Version>3.0.1</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SwiftState" Version="1.2.0" />
+      <PackageReference Include="SwiftState" Version="2.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Description

- Updated SwiftState dependency to version 2.0.0.
- Refactored `TokenReaderStateMachineFactory` to remove `TokenizerStateMachineContext` and simplify transition building logic.
- Enhanced `CsvTests` to handle escaped quotes and validate expected lexeme output.
- Bumped the version to `3.0.1` to reflect these changes.