### PR TITLE
Fix fallback logic in TokenReader for longest match

### DIFF
--- a/Tokensharp.Tests/LessThanFooTests.cs
+++ b/Tokensharp.Tests/LessThanFooTests.cs
@@ -1,0 +1,54 @@
+﻿using Tokensharp.StateMachine;
+
+namespace Tokensharp.Tests;
+
+public record LessThanFooTokenTypes(string Identifier)
+    : TokenType<LessThanFooTokenTypes>(Identifier), ITokenType<LessThanFooTokenTypes>
+{
+    public static readonly LessThanFooTokenTypes LessThanFoo = new("<Foo");
+    public static readonly LessThanFooTokenTypes LessThanFooB = new("<FooB");
+    public static readonly LessThanFooTokenTypes LessThanFooBar = new("<FooBar");
+
+    public static TokenConfiguration<LessThanFooTokenTypes> Configuration { get; } =
+        new TokenConfigurationBuilder<LessThanFooTokenTypes>
+        {
+            LessThanFoo,
+            LessThanFooB,
+            LessThanFooBar
+        }.Build();
+    
+    public static LessThanFooTokenTypes Create(string token) => new(token);
+}
+
+public class LessThanFooTests : TokenizerTestBase<LessThanFooTokenTypes>
+{
+    [Test]
+    public void TestLongestMatch_LessThanFoo()
+    {
+        RunTest("123<Foo <FooB456<Foo789<FooB <FooABC<FooBar123<Foo <FooB456<Foo789<FooB <FooABC", [
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.Number, "123"),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.LessThanFoo),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.WhiteSpace, " "),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.LessThanFooB),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.Number, "456"),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.LessThanFoo),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.Number, "789"),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.LessThanFooB),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.WhiteSpace, " "),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.LessThanFoo),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.Text, "ABC"),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.LessThanFooBar),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.Number, "123"),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.LessThanFoo),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.WhiteSpace, " "),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.LessThanFooB),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.Number, "456"),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.LessThanFoo),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.Number, "789"),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.LessThanFooB),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.WhiteSpace, " "),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.LessThanFoo),
+            new TestCase<LessThanFooTokenTypes>(LessThanFooTokenTypes.Text, "ABC")
+        ]);
+    }
+}

--- a/Tokensharp.Tests/LongestMatchTests.cs
+++ b/Tokensharp.Tests/LongestMatchTests.cs
@@ -4,12 +4,14 @@ public record LongestMatchTokenTypes(string Identifier)
     : TokenType<LongestMatchTokenTypes>(Identifier), ITokenType<LongestMatchTokenTypes>
 {
     public static readonly LongestMatchTokenTypes Foo = new("foo");
+    public static readonly LongestMatchTokenTypes Foob = new("foob");
     public static readonly LongestMatchTokenTypes Foobar = new("foobar");
 
     public static TokenConfiguration<LongestMatchTokenTypes> Configuration { get; } =
         new TokenConfigurationBuilder<LongestMatchTokenTypes>
         {
             Foo,
+            Foob,
             Foobar
         }.Build();
     
@@ -38,9 +40,9 @@ public class LongestMatchTests : TokenizerTestBase<LongestMatchTokenTypes>
         // Since "b" is not a valid token start, the next call might fail or return text if configured.
         // But here we just check the first token.
         
-        RunTest("foob", [
+        RunTest("fooc", [
             new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Foo),
-            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Text, "b")
+            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Text, "c")
         ]);
     }
 
@@ -48,8 +50,8 @@ public class LongestMatchTests : TokenizerTestBase<LongestMatchTokenTypes>
     public void TestLongestMatch_Foobac()
     {
         RunTest("foobac", [
-            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Foo),
-            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Text, "bac")
+            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Foob),
+            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Text, "ac")
         ]);
     }
 
@@ -57,9 +59,28 @@ public class LongestMatchTests : TokenizerTestBase<LongestMatchTokenTypes>
     public void TestLongestMatch_FoobacWithSpace()
     {
         RunTest("foobac ", [
-            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Foo),
-            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Text, "bac"),
+            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Foob),
+            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Text, "ac"),
             new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.WhiteSpace, " ")
+        ]);
+    }
+
+    [Test]
+    public void TestLongestMatch_FoobWithNumber()
+    {
+        RunTest("foob1", [
+            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Foob),
+            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Number, "1")
+        ]);
+    }
+
+    [Test]
+    public void TestLongestMatch_WhiteSpaceThenFoobWithNumber()
+    {
+        RunTest(" foob1", [
+            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.WhiteSpace, " "),
+            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Foob),
+            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Number, "1")
         ]);
     }
 

--- a/Tokensharp/StateMachine/TokenReaderStateMachineFactory.cs
+++ b/Tokensharp/StateMachine/TokenReaderStateMachineFactory.cs
@@ -104,7 +104,7 @@ internal static class TokenReaderStateMachineFactory<TTokenType> where TTokenTyp
             {
                 TokenizerStateId<TTokenType> terminalStateId =
                     TokenizerStateId<TTokenType>.CreateTerminal(node.StateId.TokenType);
-                
+
                 currentNodeStateBuilder.Default(terminalStateId, true);
 
                 fallbackStateId = terminalStateId;

--- a/Tokensharp/TokenReader.cs
+++ b/Tokensharp/TokenReader.cs
@@ -50,7 +50,9 @@ public ref struct TokenReader<TTokenType>(
 
                 if (currentState.IsTerminal)
                 {
-                    if (previousLongestState is not null && (!previousLongestState.Id.TokenType.IsUserDefined || currentState.Id.TokenType == previousLongestState.Id.TokenType))
+                    if (previousLongestState is not null && (!previousLongestState.Id.TokenType.IsUserDefined ||
+                                                             currentState.Id.TokenType ==
+                                                             previousLongestState.Id.TokenType))
                     {
                         tokenType = previousLongestState.Id.TokenType;
                         lexemeLength = previousLongestLexemeLength;
@@ -63,10 +65,10 @@ public ref struct TokenReader<TTokenType>(
 
                     break;
                 }
-                
+
                 if (previousState != stateMachine.StartState && previousState.Id.TokenType != currentState.Id.TokenType)
                 {
-                    // Is our new state matches our previous longest, then we've fallen back to the previous token type
+                    // If our new state matches our previous longest, then we've fallen back to the previous token type
                     // This is most common when parsing text when a potential token fails and falls back to text.
                     if (previousLongestState == currentState)
                     {
@@ -75,6 +77,15 @@ public ref struct TokenReader<TTokenType>(
                     }
                     else
                     {
+                        if (previousLongestState is not null && (!previousLongestState.Id.TokenType.IsUserDefined ||
+                                                                 currentState.Id.TokenType ==
+                                                                 previousLongestState.Id.TokenType))
+                        {
+                            tokenType = previousLongestState.Id.TokenType;
+                            lexemeLength = previousLongestLexemeLength;
+                            break;
+                        }
+
                         previousLongestState = previousState;
                         previousLongestLexemeLength = characterCount;
                     }

--- a/Tokensharp/Tokensharp.csproj
+++ b/Tokensharp/Tokensharp.csproj
@@ -9,7 +9,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>3.0.1</Version>
+        <Version>3.0.2</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 


### PR DESCRIPTION
### Summary

This pull request fixes the fallback logic in `TokenReader` to ensure it yields the previous longest match when transitioning to a different token type. 

### Changes

- Updated `TokenReader` logic to handle transitions between token types properly.
- Added `Foob` token to `LongestMatchTests` and updated related test cases.
- Introduced `LessThanFooTests` for validating overlapping token cases with symbols.
- Incremented the version to 3.0.2.
