### PR TITLE
Sort token definitions by lexeme length in ToTokenTree

### DIFF
--- a/Tokensharp.Tests/LessThanFooTests.cs
+++ b/Tokensharp.Tests/LessThanFooTests.cs
@@ -13,8 +13,8 @@ public record LessThanFooTokenTypes(string Identifier)
         new TokenConfigurationBuilder<LessThanFooTokenTypes>
         {
             LessThanFoo,
-            LessThanFooB,
-            LessThanFooBar
+            LessThanFooBar,
+            LessThanFooB
         }.Build();
     
     public static LessThanFooTokenTypes Create(string token) => new(token);

--- a/Tokensharp/TokenConfigurationExtensions.cs
+++ b/Tokensharp/TokenConfigurationExtensions.cs
@@ -15,7 +15,7 @@ internal static class TokenConfigurationExtensions
 
             var stateNameBuilder = new StringBuilder();
 
-            foreach (LexemeToTokenType<TTokenType> tokenDefinition in tokenConfiguration)
+            foreach (LexemeToTokenType<TTokenType> tokenDefinition in tokenConfiguration.OrderBy(t => t.Lexeme.Length))
             {
                 TokenTreeNode<TTokenType>? currentNode = null;
             


### PR DESCRIPTION
```
### Summary

This pull request updates the ToTokenTree functionality to ensure that token definitions are processed in order of their length, regardless of the order in which they are defined in the configuration. The change improves consistency during token tree construction.

### Changes
- Sort token definitions by lexeme length.
- Updated LessThanFooTests to validate the new sorting behavior.

```