### PR TITLE
Fix buffer shifting logic in ReadBuffer

### DIFF
--- a/Tokensharp/ReadBuffer.cs
+++ b/Tokensharp/ReadBuffer.cs
@@ -75,8 +75,12 @@ internal struct ReadBuffer(int initialBufferSize) : IDisposable
             }
             else if (_count != 0)
             {
-                _buffer.AsSpan(charsConsumed).CopyTo(_buffer.AsSpan(0, _count));
+                _buffer.AsSpan(charsConsumed, _count).CopyTo(_buffer.AsSpan(0, _count));
             }
+        }
+        else if (_count != 0)
+        {
+            _buffer.AsSpan(charsConsumed, _count).CopyTo(_buffer.AsSpan(0, _count));
         }
     }
 


### PR DESCRIPTION
### Summary of Changes
- Corrected an issue with the source span slice to prevent size mismatch exceptions.
- Implemented buffer shifting logic to handle the situation when the end of the reader is reached.