### PR TITLE
Refactor ReadBuffer logic and bump version to 3.1.1

### DIFF
--- a/Tokensharp/Tokensharp.csproj
+++ b/Tokensharp/Tokensharp.csproj
@@ -9,7 +9,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>3.1.0</Version>
+        <Version>3.1.1</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 


### PR DESCRIPTION
Refactored `ReadBuffer` implementation for improved clarity and maintainability. Key changes include:
- Renaming the internal `_count` variable to `_length`.
- Consolidating buffer handling logic by simplifying `AdvanceBuffer` and relocating buffer expansion logic to a dedicated `ExpandBuffer` method.
- Updating `Read` and `ReadAsync` methods to ensure buffer expansion when full.

This pull request also updates the version to 3.1.1.