### PR TITLE
Bump version to 3.1.2 and optimize ReadBuffer

### DIFF
--- a/Tokensharp/Tokensharp.csproj
+++ b/Tokensharp/Tokensharp.csproj
@@ -9,7 +9,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>3.1.1</Version>
+        <Version>3.1.2</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 


### PR DESCRIPTION
### Description

- Updated the version to 3.1.2.
- Optimized `ReadBuffer` to reduce unnecessary memory copying:
  - Refactored `AdvanceBuffer` to use index incrementation instead of immediate memory shifting.
  - Renamed `ExpandBuffer` to `CheckBuffer` and consolidated buffer expansion and shifting responsibilities.