### PR TITLE
Add tests for handling incomplete tokens

### DIFF
--- a/Tokensharp.Tests/LongestMatchTests.cs
+++ b/Tokensharp.Tests/LongestMatchTests.cs
@@ -113,4 +113,13 @@ public class LongestMatchTests : TokenizerTestBase<LongestMatchTokenTypes>
             new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.WhiteSpace, " ")
         ]);
     }
+
+    [Test]
+    public void TestLongestMath_IncompleteFooFollowedByFoo()
+    {
+        RunTest("fofoo", [
+            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Text, "fo"),
+            new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Foo)
+        ]);
+    }
 }

--- a/Tokensharp.Tests/LongestMatchTests.cs
+++ b/Tokensharp.Tests/LongestMatchTests.cs
@@ -115,7 +115,7 @@ public class LongestMatchTests : TokenizerTestBase<LongestMatchTokenTypes>
     }
 
     [Test]
-    public void TestLongestMath_IncompleteFooFollowedByFoo()
+    public void TestLongestMatch_IncompleteFooFollowedByFoo()
     {
         RunTest("fofoo", [
             new TestCase<LongestMatchTokenTypes>(LongestMatchTokenTypes.Text, "fo"),

--- a/Tokensharp.Tests/TemplateLanguageTests.cs
+++ b/Tokensharp.Tests/TemplateLanguageTests.cs
@@ -38,4 +38,17 @@ public class TemplateLanguageTests : TokenizerTestBase<TemplateLanguageTokenType
             new TestCase<TemplateLanguageTokenTypes>(TemplateLanguageTokenTypes.EndBinding),
         ]);
     }
+
+    [Test]
+    public void TextHasIncompleteTokenFollowedByValidToken()
+    {
+        RunTest("{{{}}text}}",
+        [
+            new TestCase<TemplateLanguageTokenTypes>(TemplateLanguageTokenTypes.StartBinding),
+            new TestCase<TemplateLanguageTokenTypes>(TemplateLanguageTokenTypes.Text, "{"),
+            new TestCase<TemplateLanguageTokenTypes>(TemplateLanguageTokenTypes.EndBinding),
+            new TestCase<TemplateLanguageTokenTypes>(TemplateLanguageTokenTypes.Text, "text"),
+            new TestCase<TemplateLanguageTokenTypes>(TemplateLanguageTokenTypes.EndBinding),
+        ]);
+    }
 }


### PR DESCRIPTION
Additional tests were added to ensure the correct handling of scenarios where incomplete tokens are followed by valid tokens. These include:

- `TestLongestMath_IncompleteFooFollowedByFoo` added to `LongestMatchTests`.
- `TextHasIncompleteTokenFollowedByValidToken` added to `TemplateLanguageTests`.