### PR TITLE
Simplify and refactor CsvBenchmark configuration

### DIFF
--- a/Tokensharp.Benchmark/CsvBenchmark.cs
+++ b/Tokensharp.Benchmark/CsvBenchmark.cs
@@ -1,14 +1,10 @@
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Columns;
-using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Loggers;
 using Tokensharp.StateMachine;
 
 namespace Tokensharp.Benchmark;
 
+[SimpleJob]
 [MemoryDiagnoser]
-[Config(typeof(Config))]
 public class CsvBenchmark
 {
     private const string TestStr = """
@@ -19,31 +15,7 @@ public class CsvBenchmark
     
     private string? _largeTestStr;
     
-    private TokenParserStateMachine<CsvTokenTypes>? _tokenReaderStateMachine;
-
-    public class Config : ManualConfig
-    {
-        private static readonly string[] TargetVersions = [
-            "2.0.0",
-            "3.0.0-beta.1",
-            "3.0.0-beta.2",
-            "3.0.0-beta.3"
-        ];
-        
-        public Config()
-        {
-            foreach (string version in TargetVersions)
-            {
-                AddJob(Job.MediumRun
-                    //.WithMsBuildArguments($"/p:SwiftStateVersion={version}")
-                    //.WithId($"v{version}")
-                );
-            }
-
-            AddColumnProvider(DefaultColumnProviders.Instance);
-            AddLogger(ConsoleLogger.Default);
-        }
-    }
+    private TokenReaderStateMachine<CsvTokenTypes>? _tokenReaderStateMachine;
     
     [GlobalSetup]
     public void Setup()
@@ -56,7 +28,7 @@ public class CsvBenchmark
             builder.Append("\r\n");
         }
         _largeTestStr = builder.ToString(); 
-        _tokenReaderStateMachine = TokenParserStateMachine<CsvTokenTypes>.Default;
+        _tokenReaderStateMachine = TokenReaderStateMachine<CsvTokenTypes>.Default;
     }
 
     [Benchmark]
@@ -82,7 +54,7 @@ public class CsvBenchmark
         var tokenParser = new TokenParser<CsvTokenTypes>(_tokenReaderStateMachine!);
         while (tokenParser.TryParseToken(csvSpan, false, out TokenType<CsvTokenTypes>? _, out int length))
             csvSpan = csvSpan[length..];
-    }/*
+    }
     
     [Benchmark]
     public void ParseCsv_Small()
@@ -112,5 +84,5 @@ public class CsvBenchmark
     {
         using IEnumerator<Token<CsvTokenTypes>> enumerator = Tokenizer.EnumerateTokens(_largeTestStr!, _tokenReaderStateMachine!).GetEnumerator();
         while (enumerator.MoveNext()) ;
-    }*/
+    }
 }

--- a/Tokensharp.Benchmark/CsvBenchmark.cs
+++ b/Tokensharp.Benchmark/CsvBenchmark.cs
@@ -1,10 +1,14 @@
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
 using Tokensharp.StateMachine;
 
 namespace Tokensharp.Benchmark;
 
-[SimpleJob]
 [MemoryDiagnoser]
+[Config(typeof(Config))]
 public class CsvBenchmark
 {
     private const string TestStr = """
@@ -14,7 +18,33 @@ public class CsvBenchmark
                                    """;
     
     private string? _largeTestStr;
+    
+    private TokenParserStateMachine<CsvTokenTypes>? _tokenReaderStateMachine;
 
+    public class Config : ManualConfig
+    {
+        private static readonly string[] TargetVersions = [
+            "2.0.0",
+            "3.0.0-beta.1",
+            "3.0.0-beta.2",
+            "3.0.0-beta.3"
+        ];
+        
+        public Config()
+        {
+            foreach (string version in TargetVersions)
+            {
+                AddJob(Job.MediumRun
+                    //.WithMsBuildArguments($"/p:SwiftStateVersion={version}")
+                    //.WithId($"v{version}")
+                );
+            }
+
+            AddColumnProvider(DefaultColumnProviders.Instance);
+            AddLogger(ConsoleLogger.Default);
+        }
+    }
+    
     [GlobalSetup]
     public void Setup()
     {
@@ -25,14 +55,40 @@ public class CsvBenchmark
             builder.Append(TestStr);
             builder.Append("\r\n");
         }
-        _largeTestStr = builder.ToString();
+        _largeTestStr = builder.ToString(); 
+        _tokenReaderStateMachine = TokenParserStateMachine<CsvTokenTypes>.Default;
     }
+
+    [Benchmark]
+    public bool TokenParser_SingleToken()
+    {
+        var tokenParser = new TokenParser<CsvTokenTypes>(_tokenReaderStateMachine!);
+        return tokenParser.TryParseToken(TestStr, false, out TokenType<CsvTokenTypes>? _, out int _);
+    }
+
+    [Benchmark]
+    public void TokenParser_Small()
+    {
+        ReadOnlySpan<char> csvSpan = TestStr.AsSpan();
+        var tokenParser = new TokenParser<CsvTokenTypes>(_tokenReaderStateMachine!);
+        while (tokenParser.TryParseToken(csvSpan, false, out TokenType<CsvTokenTypes>? _, out int length))
+            csvSpan = csvSpan[length..];
+    }
+
+    [Benchmark]
+    public void TokenParser_Large()
+    {
+        ReadOnlySpan<char> csvSpan = _largeTestStr.AsSpan();
+        var tokenParser = new TokenParser<CsvTokenTypes>(_tokenReaderStateMachine!);
+        while (tokenParser.TryParseToken(csvSpan, false, out TokenType<CsvTokenTypes>? _, out int length))
+            csvSpan = csvSpan[length..];
+    }/*
     
     [Benchmark]
     public void ParseCsv_Small()
     {
         ReadOnlySpan<char> csvSpan = TestStr.AsSpan();
-        while (Tokenizer.TryParseToken(csvSpan, false, out TokenType<CsvTokenTypes>? _, out ReadOnlySpan<char> lexeme))
+        while (Tokenizer.TryParseToken(csvSpan, _tokenReaderStateMachine!, false, out TokenType<CsvTokenTypes>? _, out ReadOnlySpan<char> lexeme))
             csvSpan = csvSpan[lexeme.Length..];
     }
 
@@ -40,21 +96,21 @@ public class CsvBenchmark
     public void ParseCsv_Large()
     {
         ReadOnlySpan<char> csvSpan = _largeTestStr.AsSpan();
-        while (Tokenizer.TryParseToken(csvSpan, false, out TokenType<CsvTokenTypes>? _, out ReadOnlySpan<char> lexeme))
+        while (Tokenizer.TryParseToken(csvSpan, _tokenReaderStateMachine!, false, out TokenType<CsvTokenTypes>? _, out ReadOnlySpan<char> lexeme))
             csvSpan = csvSpan[lexeme.Length..];
     }
 
     [Benchmark]
     public void EnumerateTokens_Small()
     {
-        using IEnumerator<Token<CsvTokenTypes>> enumerator = Tokenizer.EnumerateTokens<CsvTokenTypes>(TestStr).GetEnumerator();
+        using IEnumerator<Token<CsvTokenTypes>> enumerator = Tokenizer.EnumerateTokens(TestStr, _tokenReaderStateMachine!).GetEnumerator();
         while (enumerator.MoveNext()) ;
     }
 
     [Benchmark]
     public void EnumerateTokens_Large()
     {
-        using IEnumerator<Token<CsvTokenTypes>> enumerator = Tokenizer.EnumerateTokens<CsvTokenTypes>(_largeTestStr!).GetEnumerator();
+        using IEnumerator<Token<CsvTokenTypes>> enumerator = Tokenizer.EnumerateTokens(_largeTestStr!, _tokenReaderStateMachine!).GetEnumerator();
         while (enumerator.MoveNext()) ;
-    }
+    }*/
 }

--- a/Tokensharp.Benchmark/Program.cs
+++ b/Tokensharp.Benchmark/Program.cs
@@ -1,4 +1,11 @@
-﻿using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Running;
 using Tokensharp.Benchmark;
 
-BenchmarkRunner.Run<CsvBenchmark>();
+#if DEBUG
+var config = new DebugInProcessConfig();
+#else
+var config = new CsvBenchmark.Config();
+#endif
+
+BenchmarkRunner.Run<CsvBenchmark>(config, args);

--- a/Tokensharp.Benchmark/Program.cs
+++ b/Tokensharp.Benchmark/Program.cs
@@ -5,7 +5,5 @@ using Tokensharp.Benchmark;
 #if DEBUG
 var config = new DebugInProcessConfig();
 #else
-var config = new CsvBenchmark.Config();
+BenchmarkRunner.Run<CsvBenchmark>();
 #endif
-
-BenchmarkRunner.Run<CsvBenchmark>(config, args);


### PR DESCRIPTION
### Description

This pull request simplifies and refactors the `CsvBenchmark` class by:

- Removing the manual `Config` class and unused usings from the codebase.
- Adding the `[SimpleJob]` attribute to streamline benchmark configuration.
- Updating `_tokenReaderStateMachine` to use the `TokenReaderStateMachine`.
- Restoring previously commented benchmarks: `ParseCsv` and `EnumerateTokens`.
- Refining benchmark configuration with the introduction of `TokenParser` benchmarks and manual config for debug scenarios.
- Adjusting `Program.cs` to use `DebugInProcessConfig` in debug mode, while removing unnecessary custom config.