### PR TITLE
Replace PredicateMap with FrozenDictionary

### DIFF
--- a/Tokensharp/StateMachine/MultipleStateLookup.cs
+++ b/Tokensharp/StateMachine/MultipleStateLookup.cs
@@ -1,13 +1,13 @@
+using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
-using PredicateMap;
 
 namespace Tokensharp.StateMachine;
 
-internal class MultipleStateLookup<TTokenType>(IPredicateMap<char, State<TTokenType>> predicateMap)
+internal class MultipleStateLookup<TTokenType>(FrozenDictionary<char, State<TTokenType>> predicateMap)
     : IStateLookup<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
     public bool TryGetState(char c, [NotNullWhen(true)] out State<TTokenType>? state)
     {
-        return predicateMap.TryGet(c, out state);
+        return predicateMap.TryGetValue(c, out state);
     }
 }

--- a/Tokensharp/StateMachine/StateLookupBuilder.cs
+++ b/Tokensharp/StateMachine/StateLookupBuilder.cs
@@ -1,5 +1,5 @@
+using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
-using PredicateMap;
 
 namespace Tokensharp.StateMachine;
 
@@ -19,12 +19,12 @@ internal class StateLookupBuilder<TTokenType> where TTokenType : TokenType<TToke
         if (_states.Count == 0)
             return _noStatesLookup;
 
-        var swiftStateBuilder = new PredicateMapBuilder<char, State<TTokenType>>();
+        var swiftStateBuilder = new Dictionary<char, State<TTokenType>>();
 
         foreach ((char character, State<TTokenType> state) in _states)
             swiftStateBuilder.Add(character, state);
 
-        return new MultipleStateLookup<TTokenType>(swiftStateBuilder.ToPredicateMap());
+        return new MultipleStateLookup<TTokenType>(swiftStateBuilder.ToFrozenDictionary());
     }
 
     private class AlwaysFalseLookup : IStateLookup<TTokenType>

--- a/Tokensharp/Tokensharp.csproj
+++ b/Tokensharp/Tokensharp.csproj
@@ -9,7 +9,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>4.0.0</Version>
+        <Version>4.0.1</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 

--- a/Tokensharp/Tokensharp.csproj
+++ b/Tokensharp/Tokensharp.csproj
@@ -26,8 +26,4 @@
         <None Include="$(SolutionDir)\LICENSE" Pack="true" PackagePath="" />
     </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="PredicateMap" Version="1.0.1" />
-    </ItemGroup>
-
 </Project>


### PR DESCRIPTION
### Summary of Changes
- Eliminated the `PredicateMap` package dependency.
- Replaced `PredicateMap` usages with `System.Collections.Frozen.FrozenDictionary` for state lookups.

### Additional Context
This change streamlines the dependency management and takes advantage of the performance benefits of `FrozenDictionary`. No external functionality has been altered.