### PR TITLE
Refactor state machine logic in TokenParser

### DIFF
--- a/Tokensharp/StateMachine/CheckForTokenState.cs
+++ b/Tokensharp/StateMachine/CheckForTokenState.cs
@@ -20,7 +20,7 @@ internal class CheckForTokenState<TTokenType>(
 
     public EndOfTokenState<TTokenType> EndOfTokenStateInstance => field ??= fallbackStateEndOfTokenStateAccessor.EndOfTokenStateInstance;
 
-    protected override bool TryGetNextState(char c, [NotNullWhen(true)] out State<TTokenType>? nextState)
+    protected override bool TryGetNextState(char c, [NotNullWhen(true)] out IState<TTokenType>? nextState)
     {
         Debug.Assert(!Node.IsEndOfToken);
         
@@ -39,7 +39,7 @@ internal class CheckForTokenState<TTokenType>(
         return true;
     }
 
-    protected override bool TryGetDefaultState([NotNullWhen(true)] out State<TTokenType>? defaultState)
+    protected override bool TryGetDefaultState([NotNullWhen(true)] out IState<TTokenType>? defaultState)
     {
         Debug.Assert(!Node.IsEndOfToken);
         

--- a/Tokensharp/StateMachine/EndOfPotentialTokenState.cs
+++ b/Tokensharp/StateMachine/EndOfPotentialTokenState.cs
@@ -3,7 +3,7 @@ namespace Tokensharp.StateMachine;
 internal class EndOfPotentialTokenState<TTokenType>(TTokenType tokenType)
     : EndOfTokenState<TTokenType>(tokenType) where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    protected override void UpdateCounts(ref StateMachineContext context)
+    public override void UpdateCounts(ref StateMachineContext context)
     {
         context.PotentialLexemeLength++;
         context.FallbackLexemeLength = context.PotentialLexemeLength;

--- a/Tokensharp/StateMachine/EndOfSingleCharacterTokenState.cs
+++ b/Tokensharp/StateMachine/EndOfSingleCharacterTokenState.cs
@@ -5,7 +5,7 @@ namespace Tokensharp.StateMachine;
 internal class EndOfSingleCharacterTokenState<TTokenType>(TTokenType tokenType) 
     : EndOfTokenState<TTokenType>(tokenType) where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    public override bool IsEndOfToken(ref StateMachineContext context, out int length, [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
+    public override bool TryFinalizeToken(ref StateMachineContext context, out int length, [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
     {
         length = 1;
         tokenType = TokenType;

--- a/Tokensharp/StateMachine/EndOfTokenState.cs
+++ b/Tokensharp/StateMachine/EndOfTokenState.cs
@@ -8,11 +8,11 @@ internal class EndOfTokenState<TTokenType>(TTokenType tokenType)
 {
     public TTokenType TokenType { get; } = tokenType;
 
-    protected override TransitionResult TransitionResult => TransitionResult.EndOfToken;
+    public override bool IsEndOfToken => true;
 
     public EndOfTokenState<TTokenType> EndOfTokenStateInstance => this;
 
-    protected override void UpdateCounts(ref StateMachineContext context)
+    public override void UpdateCounts(ref StateMachineContext context)
     {
         // NoOp
     }
@@ -24,13 +24,13 @@ internal class EndOfTokenState<TTokenType>(TTokenType tokenType)
         return true;
     }
 
-    protected override bool TryGetNextState(char c, [NotNullWhen(true)] out State<TTokenType>? nextState)
+    protected override bool TryGetNextState(char c, [NotNullWhen(true)] out IState<TTokenType>? nextState)
     {
         nextState = null;
         return false;
     }
 
-    protected override bool TryGetDefaultState([NotNullWhen(true)] out State<TTokenType>? defaultState)
+    protected override bool TryGetDefaultState([NotNullWhen(true)] out IState<TTokenType>? defaultState)
     {
         defaultState = null;
         return false;

--- a/Tokensharp/StateMachine/EndOfTokenState.cs
+++ b/Tokensharp/StateMachine/EndOfTokenState.cs
@@ -24,7 +24,8 @@ internal class EndOfTokenState<TTokenType>(TTokenType tokenType)
 
     protected override bool TryGetNextState(char c, [NotNullWhen(true)] out State<TTokenType>? nextState)
     {
-        return TryGetDefaultState(out nextState);
+        nextState = null;
+        return false;
     }
 
     protected override bool TryGetDefaultState([NotNullWhen(true)] out State<TTokenType>? defaultState)

--- a/Tokensharp/StateMachine/EndOfTokenState.cs
+++ b/Tokensharp/StateMachine/EndOfTokenState.cs
@@ -7,7 +7,9 @@ internal class EndOfTokenState<TTokenType>(TTokenType tokenType)
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
     public TTokenType TokenType { get; } = tokenType;
-    
+
+    protected override TransitionResult TransitionResult => TransitionResult.EndOfToken;
+
     public EndOfTokenState<TTokenType> EndOfTokenStateInstance => this;
 
     protected override void UpdateCounts(ref StateMachineContext context)
@@ -15,7 +17,7 @@ internal class EndOfTokenState<TTokenType>(TTokenType tokenType)
         // NoOp
     }
 
-    public override bool IsEndOfToken(ref StateMachineContext context, out int length, [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
+    public override bool TryFinalizeToken(ref StateMachineContext context, out int length, [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
     {
         length = context.FallbackLexemeLength > 0 ? context.FallbackLexemeLength : context.PotentialLexemeLength;
         tokenType = TokenType;

--- a/Tokensharp/StateMachine/FailedTokenCheckState.cs
+++ b/Tokensharp/StateMachine/FailedTokenCheckState.cs
@@ -3,7 +3,7 @@ namespace Tokensharp.StateMachine;
 internal class FailedTokenCheckState<TTokenType>(State<TTokenType> fallbackState, IStateCharacterCheck fallbackStateCharacterCheck)
     : MixedCharacterFailedTokenCheckState<TTokenType>(fallbackState, fallbackStateCharacterCheck) where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    protected override void UpdateCounts(ref StateMachineContext context)
+    public override void UpdateCounts(ref StateMachineContext context)
     {
         context.PotentialLexemeLength++;
         base.UpdateCounts(ref context);

--- a/Tokensharp/StateMachine/IState.cs
+++ b/Tokensharp/StateMachine/IState.cs
@@ -10,6 +10,6 @@ internal interface IStateCharacterCheck
 internal interface IState<TTokenType> : ITransitionHandler<TTokenType>
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    bool IsEndOfToken(ref StateMachineContext context, out int lexemeLength,
+    bool TryFinalizeToken(ref StateMachineContext context, out int lexemeLength,
         [NotNullWhen(true)] out TokenType<TTokenType>? tokenType);
 }

--- a/Tokensharp/StateMachine/IState.cs
+++ b/Tokensharp/StateMachine/IState.cs
@@ -10,6 +10,9 @@ internal interface IStateCharacterCheck
 internal interface IState<TTokenType> : ITransitionHandler<TTokenType>
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
+    bool IsEndOfToken { get; }
+    void UpdateCounts(ref StateMachineContext context);
+
     bool TryFinalizeToken(ref StateMachineContext context, out int lexemeLength,
         [NotNullWhen(true)] out TokenType<TTokenType>? tokenType);
 }

--- a/Tokensharp/StateMachine/IStateLookup.cs
+++ b/Tokensharp/StateMachine/IStateLookup.cs
@@ -4,5 +4,5 @@ namespace Tokensharp.StateMachine;
 
 internal interface IStateLookup<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    bool TryGetState(char c, [NotNullWhen(true)] out State<TTokenType>? state);
+    bool TryGetState(char c, [NotNullWhen(true)] out IState<TTokenType>? state);
 }

--- a/Tokensharp/StateMachine/ITransitionHandler.cs
+++ b/Tokensharp/StateMachine/ITransitionHandler.cs
@@ -5,13 +5,6 @@ namespace Tokensharp.StateMachine;
 internal interface ITransitionHandler<TTokenType> 
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    TransitionResult TryTransition(char c, ref StateMachineContext context, out IState<TTokenType>? nextState);
+    bool TryTransition(char c, ref StateMachineContext context, [NotNullWhen(true)] out IState<TTokenType>? nextState);
     bool TryDefaultTransition(ref StateMachineContext context, [NotNullWhen(true)] out IState<TTokenType>? defaultState);
-}
-
-internal enum TransitionResult
-{
-    NewState,
-    EndOfToken,
-    Failure
 }

--- a/Tokensharp/StateMachine/ITransitionHandler.cs
+++ b/Tokensharp/StateMachine/ITransitionHandler.cs
@@ -5,6 +5,13 @@ namespace Tokensharp.StateMachine;
 internal interface ITransitionHandler<TTokenType> 
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    bool TryTransition(char c, ref StateMachineContext context, [NotNullWhen(true)] out IState<TTokenType>? nextState);
+    TransitionResult TryTransition(char c, ref StateMachineContext context, out IState<TTokenType>? nextState);
     bool TryDefaultTransition(ref StateMachineContext context, [NotNullWhen(true)] out IState<TTokenType>? defaultState);
+}
+
+internal enum TransitionResult
+{
+    NewState,
+    EndOfToken,
+    Failure
 }

--- a/Tokensharp/StateMachine/MixedCharacterCheckFailedEndOfTokenState.cs
+++ b/Tokensharp/StateMachine/MixedCharacterCheckFailedEndOfTokenState.cs
@@ -4,7 +4,7 @@ internal class MixedCharacterCheckFailedEndOfTokenState<TTokenType>(IEndOfTokenS
     : EndOfTokenState<TTokenType>(fallback.EndOfTokenStateInstance.TokenType)
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    protected override void UpdateCounts(ref StateMachineContext context)
+    public override void UpdateCounts(ref StateMachineContext context)
     {
         context.FallbackLexemeLength = context.PotentialLexemeLength;
     }

--- a/Tokensharp/StateMachine/MixedCharacterFailedTokenCheckState.cs
+++ b/Tokensharp/StateMachine/MixedCharacterFailedTokenCheckState.cs
@@ -5,20 +5,20 @@ namespace Tokensharp.StateMachine;
 internal class MixedCharacterFailedTokenCheckState<TTokenType>(State<TTokenType> fallbackState, IStateCharacterCheck fallbackStateCharacterCheck)
     : State<TTokenType>, IStateCharacterCheck where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    protected override TransitionResult TransitionResult => TransitionResult.NewState;
+    public override bool IsEndOfToken => false;
 
-    protected override bool TryGetNextState(char c, [NotNullWhen(true)] out State<TTokenType>? nextState)
+    protected override bool TryGetNextState(char c, [NotNullWhen(true)] out IState<TTokenType>? nextState)
     {
         return TryGetDefaultState(out nextState);
     }
 
-    protected override bool TryGetDefaultState([NotNullWhen(true)] out State<TTokenType>? defaultState)
+    protected override bool TryGetDefaultState([NotNullWhen(true)] out IState<TTokenType>? defaultState)
     {
         defaultState = fallbackState;
         return true;
     }
 
-    protected override void UpdateCounts(ref StateMachineContext context)
+    public override void UpdateCounts(ref StateMachineContext context)
     {
         context.FallbackLexemeLength = context.PotentialLexemeLength;
     }

--- a/Tokensharp/StateMachine/MixedCharacterFailedTokenCheckState.cs
+++ b/Tokensharp/StateMachine/MixedCharacterFailedTokenCheckState.cs
@@ -5,6 +5,8 @@ namespace Tokensharp.StateMachine;
 internal class MixedCharacterFailedTokenCheckState<TTokenType>(State<TTokenType> fallbackState, IStateCharacterCheck fallbackStateCharacterCheck)
     : State<TTokenType>, IStateCharacterCheck where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
+    protected override TransitionResult TransitionResult => TransitionResult.NewState;
+
     protected override bool TryGetNextState(char c, [NotNullWhen(true)] out State<TTokenType>? nextState)
     {
         return TryGetDefaultState(out nextState);

--- a/Tokensharp/StateMachine/MultipleStateLookup.cs
+++ b/Tokensharp/StateMachine/MultipleStateLookup.cs
@@ -3,10 +3,10 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Tokensharp.StateMachine;
 
-internal class MultipleStateLookup<TTokenType>(FrozenDictionary<char, State<TTokenType>> predicateMap)
+internal class MultipleStateLookup<TTokenType>(FrozenDictionary<char, IState<TTokenType>> predicateMap)
     : IStateLookup<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    public bool TryGetState(char c, [NotNullWhen(true)] out State<TTokenType>? state)
+    public bool TryGetState(char c, [NotNullWhen(true)] out IState<TTokenType>? state)
     {
         return predicateMap.TryGetValue(c, out state);
     }

--- a/Tokensharp/StateMachine/NodeStateBase.cs
+++ b/Tokensharp/StateMachine/NodeStateBase.cs
@@ -6,7 +6,7 @@ namespace Tokensharp.StateMachine;
 internal abstract class NodeStateBase<TTokenType>(ITokenTreeNode<TTokenType> node)
     : State<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    protected override TransitionResult TransitionResult => TransitionResult.NewState;
+    public override bool IsEndOfToken => false;
     
     protected ITokenTreeNode<TTokenType> Node { get; } = node;
 
@@ -14,7 +14,7 @@ internal abstract class NodeStateBase<TTokenType>(ITokenTreeNode<TTokenType> nod
     
     internal IStateLookup<TTokenType> StateLookup { set => _stateLookup = value; }
 
-    protected bool TryGetStateForChildNode(char c, [NotNullWhen(true)] out State<TTokenType>? state) =>
+    protected bool TryGetStateForChildNode(char c, [NotNullWhen(true)] out IState<TTokenType>? state) =>
         _stateLookup!.TryGetState(c, out state);
 
     public override string ToString()

--- a/Tokensharp/StateMachine/NodeStateBase.cs
+++ b/Tokensharp/StateMachine/NodeStateBase.cs
@@ -6,6 +6,8 @@ namespace Tokensharp.StateMachine;
 internal abstract class NodeStateBase<TTokenType>(ITokenTreeNode<TTokenType> node)
     : State<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
+    protected override TransitionResult TransitionResult => TransitionResult.NewState;
+    
     protected ITokenTreeNode<TTokenType> Node { get; } = node;
 
     private IStateLookup<TTokenType>? _stateLookup;

--- a/Tokensharp/StateMachine/PotentialTokenState.cs
+++ b/Tokensharp/StateMachine/PotentialTokenState.cs
@@ -15,7 +15,7 @@ internal class PotentialTokenState<TTokenType>(
         ? new EndOfTokenState<TTokenType>(node.TokenType)
         : fallbackEndOfTokenStateAccessor.EndOfTokenStateInstance;
 
-    protected override bool TryGetNextState(char c, [NotNullWhen(true)] out State<TTokenType>? nextState)
+    protected override bool TryGetNextState(char c, [NotNullWhen(true)] out IState<TTokenType>? nextState)
     {
         if (TryGetStateForChildNode(c, out nextState))
             return true;
@@ -29,13 +29,13 @@ internal class PotentialTokenState<TTokenType>(
         return rootStates.TryGetState(c, out nextState) || TryGetDefaultState(out nextState);
     }
 
-    protected override bool TryGetDefaultState([NotNullWhen(true)] out State<TTokenType>? defaultState)
+    protected override bool TryGetDefaultState([NotNullWhen(true)] out IState<TTokenType>? defaultState)
     {
         defaultState = EndOfTokenStateInstance;
         return true;
     }
 
-    protected override void UpdateCounts(ref StateMachineContext context)
+    public override void UpdateCounts(ref StateMachineContext context)
     {
         context.PotentialLexemeLength++;
         if (Node.IsEndOfToken)

--- a/Tokensharp/StateMachine/StartOfCheckForTokenState.cs
+++ b/Tokensharp/StateMachine/StartOfCheckForTokenState.cs
@@ -11,7 +11,7 @@ internal class StartOfCheckForTokenState<TTokenType>(
     : CheckForTokenState<TTokenType>(node, fallback, fallbackStateEndOfTokenStateAccessor, fallbackStateCharacterCheck) 
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    protected override void UpdateCounts(ref StateMachineContext context)
+    public override void UpdateCounts(ref StateMachineContext context)
     {
         context.FallbackLexemeLength = context.PotentialLexemeLength;
         context.PotentialLexemeLength++;

--- a/Tokensharp/StateMachine/StartState.cs
+++ b/Tokensharp/StateMachine/StartState.cs
@@ -15,7 +15,7 @@ internal class StartState<TTokenType>(
     private Number<TTokenType> NumberInstance { get; } = number;
     private Text<TTokenType> TextInstance { get; } = text;
 
-    protected override bool TryGetNextState(char c, [NotNullWhen(true)] out State<TTokenType>? nextState)
+    protected override bool TryGetNextState(char c, [NotNullWhen(true)] out IState<TTokenType>? nextState)
     {
         if (TryGetStateForChildNode(c, out nextState))
             return true;
@@ -36,7 +36,7 @@ internal class StartState<TTokenType>(
         return true;
     }
 
-    protected override bool TryGetDefaultState([NotNullWhen(true)] out State<TTokenType>? defaultState)
+    protected override bool TryGetDefaultState([NotNullWhen(true)] out IState<TTokenType>? defaultState)
     {
         defaultState = null;
         return false;

--- a/Tokensharp/StateMachine/State.cs
+++ b/Tokensharp/StateMachine/State.cs
@@ -4,18 +4,20 @@ namespace Tokensharp.StateMachine;
 
 internal abstract class State<TTokenType> : IState<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    public virtual bool TryTransition(char c, ref StateMachineContext context, [NotNullWhen(true)] out IState<TTokenType>? nextState)
+    protected abstract TransitionResult TransitionResult { get; }
+
+    public virtual TransitionResult TryTransition(char c, ref StateMachineContext context, out IState<TTokenType>? nextState)
     {
         if (!TryGetNextState(c, out State<TTokenType>? state) &&
             !TryGetDefaultState(out state))
         {
             nextState = null;
-            return false;
+            return TransitionResult.Failure;
         }
         
         state.UpdateCounts(ref context);
         nextState = state;
-        return true;
+        return state.TransitionResult;
     }
 
     protected abstract bool TryGetNextState(char c, [NotNullWhen(true)] out State<TTokenType>? nextState);
@@ -35,7 +37,7 @@ internal abstract class State<TTokenType> : IState<TTokenType> where TTokenType 
 
     protected abstract bool TryGetDefaultState([NotNullWhen(true)] out State<TTokenType>? defaultState);
     
-    public virtual bool IsEndOfToken(ref StateMachineContext context, out int lexemeLength, [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
+    public virtual bool TryFinalizeToken(ref StateMachineContext context, out int lexemeLength, [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
     {
         lexemeLength = 0;
         tokenType = null;

--- a/Tokensharp/StateMachine/StateLookupBuilder.cs
+++ b/Tokensharp/StateMachine/StateLookupBuilder.cs
@@ -19,7 +19,7 @@ internal class StateLookupBuilder<TTokenType> where TTokenType : TokenType<TToke
         if (_states.Count == 0)
             return _noStatesLookup;
 
-        var swiftStateBuilder = new Dictionary<char, State<TTokenType>>();
+        var swiftStateBuilder = new Dictionary<char, IState<TTokenType>>();
 
         foreach ((char character, State<TTokenType> state) in _states)
             swiftStateBuilder.Add(character, state);
@@ -29,7 +29,7 @@ internal class StateLookupBuilder<TTokenType> where TTokenType : TokenType<TToke
 
     private class AlwaysFalseLookup : IStateLookup<TTokenType>
     {
-        public bool TryGetState(char c, [NotNullWhen(true)] out State<TTokenType>? state)
+        public bool TryGetState(char c, [NotNullWhen(true)] out IState<TTokenType>? state)
         {
             state = null;
             return false;

--- a/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
+++ b/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
@@ -9,7 +9,7 @@ internal abstract class TextWhiteSpaceNumberBase<TTokenType>(ITokenTreeNode<TTok
 {
     public EndOfTokenState<TTokenType> EndOfTokenStateInstance { get; } = new(tokenType);
 
-    protected override bool TryGetNextState(char c, [NotNullWhen(true)] out State<TTokenType>? nextState)
+    protected override bool TryGetNextState(char c, [NotNullWhen(true)] out IState<TTokenType>? nextState)
     {
         if (!CharacterIsValidForState(c))
         {
@@ -23,7 +23,7 @@ internal abstract class TextWhiteSpaceNumberBase<TTokenType>(ITokenTreeNode<TTok
         return true;
     }
 
-    protected override bool TryGetDefaultState([NotNullWhen(true)] out State<TTokenType>? defaultState)
+    protected override bool TryGetDefaultState([NotNullWhen(true)] out IState<TTokenType>? defaultState)
     {
         defaultState = EndOfTokenStateInstance;
         return true;

--- a/Tokensharp/TokenParser.cs
+++ b/Tokensharp/TokenParser.cs
@@ -33,21 +33,17 @@ public readonly ref struct TokenParser<TTokenType>(TokenConfiguration<TTokenType
 
         foreach (char c in buffer)
         {
-            switch (currentState.TryTransition(c, ref context, out IState<TTokenType>? nextState))
+            if (currentState.TryTransition(c, ref context, out IState<TTokenType>? nextState))
             {
-                case TransitionResult.NewState:
-                    currentState = nextState!;
-                    break;
-                    
-                case TransitionResult.EndOfToken:
-                    if (nextState!.TryFinalizeToken(ref context, out length, out tokenType))
-                        return true;
-                    
-                    throw new InvalidDataException($"Unexpected character: {c}, Current state: {currentState}");
-
-                case TransitionResult.Failure:
-                default:
-                    throw new InvalidDataException($"Unexpected character: {c}, Current state: {currentState}");
+                currentState = nextState!;
+            }
+            else if (nextState!.TryFinalizeToken(ref context, out length, out tokenType))
+            {
+                return true;
+            }
+            else
+            {
+                throw new InvalidDataException($"Unexpected character: {c}, Current state: {currentState}");
             }
         }
 

--- a/Tokensharp/Tokensharp.csproj
+++ b/Tokensharp/Tokensharp.csproj
@@ -9,7 +9,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>4.1.0</Version>
+        <Version>4.2.0</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 


### PR DESCRIPTION
### Summary

This pull request refines the state machine logic used in the `TokenParser` by incorporating several refactors to streamline transitions and token processing. Key improvements include:

- Initial removal of the `TransitionResult` enum in favor of a boolean return value and `IsEndOfToken` property (later replaced).
- Reintroduction of `TransitionResult` enum to explicitly manage transition states: `NewState`, `EndOfToken`, and `Failure`.
- Updates to `TokenParser` to simplify and better handle state transitions via a switch-based approach.
- Modified default transition handling to improve parsing behavior when end-of-token states are reached.

### Changes

- **Simplified state transitions** by introducing better abstractions and replacing redundant mechanisms.
- **Refactored `EndOfTokenState`** to properly handle token finalization and default state fallbacks.
- Improved the **`TokenParser` logic** to improve performance and readability.

### Other Notes

- This update advances the version to `4.2.0`.