### PR TITLE
Add support for treating numbers as text in CSV parsing

### DIFF
--- a/Tokensharp.Benchmark/CsvBenchmark.cs
+++ b/Tokensharp.Benchmark/CsvBenchmark.cs
@@ -1,8 +1,4 @@
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Columns;
-using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Loggers;
 
 namespace Tokensharp.Benchmark;
 

--- a/Tokensharp.Benchmark/CsvTokenTypes.cs
+++ b/Tokensharp.Benchmark/CsvTokenTypes.cs
@@ -6,12 +6,13 @@ public record CsvTokenTypes(string Identifier) : TokenType<CsvTokenTypes>(Identi
     public static readonly CsvTokenTypes EndOfRecord = new("\r\n");
     public static readonly CsvTokenTypes DoubleQuote = new("\"");
 
-    public static TokenConfiguration<CsvTokenTypes> Configuration { get; } = new TokenConfigurationBuilder<CsvTokenTypes>(
-    [
-        Comma,
-        EndOfRecord,
-        DoubleQuote
-    ]).Build();
+    public static TokenConfiguration<CsvTokenTypes> Configuration { get; } =
+        new TokenConfigurationBuilder<CsvTokenTypes>(
+        [
+            Comma,
+            EndOfRecord,
+            DoubleQuote
+        ]) { NumbersAreText = true }.Build();
     
     public static CsvTokenTypes Create(string token) => new(token);
 }

--- a/Tokensharp.Tests/BasicTests.cs
+++ b/Tokensharp.Tests/BasicTests.cs
@@ -1,7 +1,4 @@
-﻿using System.Buffers;
-using System.Text;
-
-namespace Tokensharp.Tests;
+﻿namespace Tokensharp.Tests;
 
 public class BasicTests : TokenizerTestBase<EmptyTokens>
 {

--- a/Tokensharp.Tests/CsvTests.cs
+++ b/Tokensharp.Tests/CsvTests.cs
@@ -7,13 +7,13 @@ public record CsvTokenTypes(string Identifier) : TokenType<CsvTokenTypes>(Identi
     public static readonly CsvTokenTypes DoubleQuote = new("doubleQuote");
     public static readonly CsvTokenTypes Escape = new("escape");
 
-    public static TokenConfiguration<CsvTokenTypes> Configuration { get; } = new TokenConfigurationBuilder<CsvTokenTypes>()
-    {
-        { ",", Comma },
-        { "\r\n", EndOfRecord },
-        { "\"", DoubleQuote },
-        { "\"\"", Escape }
-    }.Build();
+    public static TokenConfiguration<CsvTokenTypes> Configuration { get; } = new TokenConfigurationBuilder<CsvTokenTypes>(
+    [
+        new LexemeToTokenType<CsvTokenTypes>(",", Comma),
+        new LexemeToTokenType<CsvTokenTypes>("\r\n", EndOfRecord),
+        new LexemeToTokenType<CsvTokenTypes>("\"", DoubleQuote),
+        new LexemeToTokenType<CsvTokenTypes>("\"\"", Escape),
+    ]) { NumbersAreText = true }.Build();
     
     public static CsvTokenTypes Create(string token) => new(token);
 }
@@ -34,7 +34,7 @@ public class CsvTests : TokenizerTestBase<CsvTokenTypes>
             new TestCase<CsvTokenTypes>(CsvTokenTypes.Text, "test"),
             new TestCase<CsvTokenTypes>(CsvTokenTypes.Comma, ","),
             new TestCase<CsvTokenTypes>(CsvTokenTypes.WhiteSpace, " "),
-            new TestCase<CsvTokenTypes>(CsvTokenTypes.Number, "123"),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.Text, "123"),
             new TestCase<CsvTokenTypes>(CsvTokenTypes.EndOfRecord, "\r\n"),
             new TestCase<CsvTokenTypes>(CsvTokenTypes.Text, "foo"),
             new TestCase<CsvTokenTypes>(CsvTokenTypes.Comma, ","),
@@ -53,7 +53,7 @@ public class CsvTests : TokenizerTestBase<CsvTokenTypes>
         
         RunTest(testStr, 
         [
-            new TestCase<CsvTokenTypes>(CsvTokenTypes.Number, "123"),
+            new TestCase<CsvTokenTypes>(CsvTokenTypes.Text, "123"),
             new TestCase<CsvTokenTypes>(CsvTokenTypes.Comma, ","),
             new TestCase<CsvTokenTypes>(CsvTokenTypes.WhiteSpace, " "),
             new TestCase<CsvTokenTypes>(CsvTokenTypes.Escape, "\"\""),

--- a/Tokensharp.Tests/EnumerateTokensTests.cs
+++ b/Tokensharp.Tests/EnumerateTokensTests.cs
@@ -1,5 +1,3 @@
-using System.Text;
-
 namespace Tokensharp.Tests;
 
 public class EnumerateTokensTests

--- a/Tokensharp.Tests/NumbersAsTextTests.cs
+++ b/Tokensharp.Tests/NumbersAsTextTests.cs
@@ -1,0 +1,47 @@
+﻿namespace Tokensharp.Tests;
+
+public record NumbersAsTextTokens(string Identifier) : TokenType<NumbersAsTextTokens>(Identifier), ITokenType<NumbersAsTextTokens>
+{
+    public static NumbersAsTextTokens Create(string identifier) => new(identifier);
+
+    public static TokenConfiguration<NumbersAsTextTokens> Configuration { get; } =
+        new TokenConfigurationBuilder<NumbersAsTextTokens> { NumbersAreText = true }.Build();
+}
+
+public class NumbersAsTextTests : TokenizerTestBase<NumbersAsTextTokens>
+{
+    [Test]
+    public void NumberIsTreatedAsText()
+    {
+        RunTest("123", TokenType<NumbersAsTextTokens>.Text, "123");
+    }
+
+    [Test]
+    public void NumberFollowedByTextIsSingleToken()
+    {
+        RunTest("1a", TokenType<NumbersAsTextTokens>.Text, "1a");
+    }
+
+    [Test]
+    public void TextFollowedByNumberIsSingleToken()
+    {
+        RunTest("a1", TokenType<NumbersAsTextTokens>.Text, "a1");
+    }
+
+    [Test]
+    public void TextNumberTextIsSingleToken()
+    {
+        RunTest("a1b", TokenType<NumbersAsTextTokens>.Text, "a1b");
+    }
+
+    [Test]
+    public void SeperateTokens()
+    {
+        RunTest("1 a",
+        [
+            new TestCase<NumbersAsTextTokens>(TokenType<NumbersAsTextTokens>.Text, "1"),
+            new TestCase<NumbersAsTextTokens>(TokenType<NumbersAsTextTokens>.WhiteSpace, " "),
+            new TestCase<NumbersAsTextTokens>(TokenType<NumbersAsTextTokens>.Text, "a")
+        ]);
+    }
+}

--- a/Tokensharp/StateMachine/CheckForTokenState.cs
+++ b/Tokensharp/StateMachine/CheckForTokenState.cs
@@ -1,12 +1,11 @@
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using Tokensharp.TokenTree;
 
 namespace Tokensharp.StateMachine;
 
 internal class CheckForTokenState<TTokenType>(
     ITokenTreeNode<TTokenType> node,
-    State<TTokenType> fallback,
+    IState<TTokenType> fallback,
     IEndOfTokenStateAccessor<TTokenType> fallbackStateEndOfTokenStateAccessor,
     IStateCharacterCheck fallbackStateCharacterCheck)
     : NodeStateBase<TTokenType>(node), IEndOfTokenStateAccessor<TTokenType>
@@ -57,7 +56,7 @@ internal class CheckForTokenState<TTokenType>(
 
     protected static CheckForTokenState<TTokenType> For(
         ITokenTreeNode<TTokenType> node,
-        State<TTokenType> fallbackState,
+        IState<TTokenType> fallbackState,
         IEndOfTokenStateAccessor<TTokenType> fallbackStateEndOfTokenAccessor,
         IStateCharacterCheck fallbackStateCharacterCheck)
     {

--- a/Tokensharp/StateMachine/CheckForTokenState.cs
+++ b/Tokensharp/StateMachine/CheckForTokenState.cs
@@ -20,7 +20,7 @@ internal class CheckForTokenState<TTokenType>(
     
     public EndOfTokenState<TTokenType> EndOfTokenStateInstance => fallbackStateEndOfTokenStateAccessor.EndOfTokenStateInstance;
 
-    protected override bool TryGetNextState(char c, out IState<TTokenType> nextState)
+    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
     {
         Debug.Assert(!Node.IsEndOfToken);
         

--- a/Tokensharp/StateMachine/EndOfTokenState.cs
+++ b/Tokensharp/StateMachine/EndOfTokenState.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Tokensharp.StateMachine;
 
 internal class EndOfTokenState<TTokenType>(TTokenType tokenType)
@@ -36,7 +34,7 @@ internal class EndOfTokenState<TTokenType>(TTokenType tokenType)
         return false;
     }
 
-    public bool CharacterIsValidForState(char c)
+    public bool CharacterIsValidForState(in char c)
     {
         return false;
     }

--- a/Tokensharp/StateMachine/EndOfTokenState.cs
+++ b/Tokensharp/StateMachine/EndOfTokenState.cs
@@ -17,14 +17,14 @@ internal class EndOfTokenState<TTokenType>(TTokenType tokenType)
         // NoOp
     }
 
-    public override bool FinalizeToken(ref StateMachineContext context, out int length, [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
+    public override bool FinalizeToken(ref StateMachineContext context, out int length, out TokenType<TTokenType> tokenType)
     {
         length = context.FallbackLexemeLength > 0 ? context.FallbackLexemeLength : context.PotentialLexemeLength;
         tokenType = TokenType;
         return true;
     }
 
-    protected override bool TryGetNextState(char c, out IState<TTokenType> nextState)
+    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
     {
         nextState = this;
         return false;

--- a/Tokensharp/StateMachine/FailedTokenCheckState.cs
+++ b/Tokensharp/StateMachine/FailedTokenCheckState.cs
@@ -1,6 +1,6 @@
 namespace Tokensharp.StateMachine;
 
-internal class FailedTokenCheckState<TTokenType>(State<TTokenType> fallbackState, IStateCharacterCheck fallbackStateCharacterCheck)
+internal class FailedTokenCheckState<TTokenType>(IState<TTokenType> fallbackState, IStateCharacterCheck fallbackStateCharacterCheck)
     : MixedCharacterFailedTokenCheckState<TTokenType>(fallbackState, fallbackStateCharacterCheck) where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
     public override void UpdateCounts(ref StateMachineContext context)

--- a/Tokensharp/StateMachine/IState.cs
+++ b/Tokensharp/StateMachine/IState.cs
@@ -1,10 +1,8 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Tokensharp.StateMachine;
 
 internal interface IStateCharacterCheck
 {
-    bool CharacterIsValidForState(char c);
+    bool CharacterIsValidForState(in char c);
 }
 
 internal interface IState<TTokenType> : ITransitionHandler<TTokenType>

--- a/Tokensharp/StateMachine/IStateLookup.cs
+++ b/Tokensharp/StateMachine/IStateLookup.cs
@@ -4,5 +4,5 @@ namespace Tokensharp.StateMachine;
 
 internal interface IStateLookup<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    bool TryGetState(char c, [NotNullWhen(true)] out IState<TTokenType>? state);
+    bool TryGetState(in char c, [NotNullWhen(true)] out IState<TTokenType>? state);
 }

--- a/Tokensharp/StateMachine/ITextWhiteSpaceNumberLookup.cs
+++ b/Tokensharp/StateMachine/ITextWhiteSpaceNumberLookup.cs
@@ -1,0 +1,7 @@
+﻿namespace Tokensharp.StateMachine;
+
+internal interface ITextWhiteSpaceNumberLookup<TTokenType>
+    where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
+{
+    TextWhiteSpaceNumberBase<TTokenType> GetState(in char c);
+}

--- a/Tokensharp/StateMachine/ITransitionHandler.cs
+++ b/Tokensharp/StateMachine/ITransitionHandler.cs
@@ -3,6 +3,6 @@ namespace Tokensharp.StateMachine;
 internal interface ITransitionHandler<TTokenType> 
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    bool TryTransition(char c, ref StateMachineContext context, out IState<TTokenType> nextState);
+    bool TryTransition(in char c, ref StateMachineContext context, out IState<TTokenType> nextState);
     bool TryDefaultTransition(ref StateMachineContext context, out IState<TTokenType> defaultState);
 }

--- a/Tokensharp/StateMachine/MixedCharacterFailedTokenCheckState.cs
+++ b/Tokensharp/StateMachine/MixedCharacterFailedTokenCheckState.cs
@@ -1,8 +1,6 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Tokensharp.StateMachine;
 
-internal class MixedCharacterFailedTokenCheckState<TTokenType>(State<TTokenType> fallbackState, IStateCharacterCheck fallbackStateCharacterCheck)
+internal class MixedCharacterFailedTokenCheckState<TTokenType>(IState<TTokenType> fallbackState, IStateCharacterCheck fallbackStateCharacterCheck)
     : State<TTokenType>, IStateCharacterCheck where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
     public override bool IsEndOfToken => false;
@@ -24,5 +22,5 @@ internal class MixedCharacterFailedTokenCheckState<TTokenType>(State<TTokenType>
         context.FallbackLexemeLength = context.PotentialLexemeLength;
     }
 
-    public bool CharacterIsValidForState(char c) => fallbackStateCharacterCheck.CharacterIsValidForState(c);
+    public bool CharacterIsValidForState(in char c) => fallbackStateCharacterCheck.CharacterIsValidForState(c);
 }

--- a/Tokensharp/StateMachine/MixedCharacterFailedTokenCheckState.cs
+++ b/Tokensharp/StateMachine/MixedCharacterFailedTokenCheckState.cs
@@ -7,7 +7,7 @@ internal class MixedCharacterFailedTokenCheckState<TTokenType>(State<TTokenType>
 {
     public override bool IsEndOfToken => false;
 
-    protected override bool TryGetNextState(char c, out IState<TTokenType> nextState)
+    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
     {
         nextState = fallbackState;
         return true;

--- a/Tokensharp/StateMachine/MultipleStateLookup.cs
+++ b/Tokensharp/StateMachine/MultipleStateLookup.cs
@@ -3,11 +3,11 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Tokensharp.StateMachine;
 
-internal class MultipleStateLookup<TTokenType>(FrozenDictionary<char, IState<TTokenType>> predicateMap)
+internal class MultipleStateLookup<TTokenType>(FrozenDictionary<char, IState<TTokenType>> dictionary)
     : IStateLookup<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    public bool TryGetState(char c, [NotNullWhen(true)] out IState<TTokenType>? state)
+    public bool TryGetState(in char c, [NotNullWhen(true)] out IState<TTokenType>? state)
     {
-        return predicateMap.TryGetValue(c, out state);
+        return dictionary.TryGetValue(c, out state);
     }
 }

--- a/Tokensharp/StateMachine/NodeStateBase.cs
+++ b/Tokensharp/StateMachine/NodeStateBase.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Tokensharp.TokenTree;
 
 namespace Tokensharp.StateMachine;

--- a/Tokensharp/StateMachine/NodeStateBase.cs
+++ b/Tokensharp/StateMachine/NodeStateBase.cs
@@ -14,7 +14,7 @@ internal abstract class NodeStateBase<TTokenType>(ITokenTreeNode<TTokenType> nod
     
     internal IStateLookup<TTokenType> StateLookup { set => _stateLookup = value; }
 
-    protected override bool TryGetNextState(char c, out IState<TTokenType> nextState)
+    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
     {
         if (_stateLookup!.TryGetState(c, out nextState!))
             return true;

--- a/Tokensharp/StateMachine/Number.cs
+++ b/Tokensharp/StateMachine/Number.cs
@@ -1,11 +1,10 @@
-using System.Diagnostics.CodeAnalysis;
-using Tokensharp.TokenTree;
+﻿using Tokensharp.TokenTree;
 
 namespace Tokensharp.StateMachine;
 
-internal class Number<TTokenType>(ITokenTreeNode<TTokenType> rootNode) 
+internal sealed class Number<TTokenType>(ITokenTreeNode<TTokenType> rootNode) 
     : TextWhiteSpaceNumberBase<TTokenType>(rootNode, TokenType<TTokenType>.Number)
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    public override bool CharacterIsValidForState(char c) => char.IsDigit(c);
+    public override bool CharacterIsValidForState(in char c) => char.IsDigit(c);
 }

--- a/Tokensharp/StateMachine/PotentialTokenState.cs
+++ b/Tokensharp/StateMachine/PotentialTokenState.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Tokensharp.TokenTree;
 
 namespace Tokensharp.StateMachine;
@@ -49,7 +48,7 @@ internal class PotentialTokenState<TTokenType>(
     }
 
     public static PotentialTokenState<TTokenType> For(ITokenTreeNode<TTokenType> node,
-        State<TTokenType> fallbackState,
+        IState<TTokenType> fallbackState,
         IEndOfTokenStateAccessor<TTokenType> fallbackEndOfTokenStateAccessor,
         IStateCharacterCheck fallbackStateCharacterCheck)
     {

--- a/Tokensharp/StateMachine/PotentialTokenState.cs
+++ b/Tokensharp/StateMachine/PotentialTokenState.cs
@@ -17,7 +17,7 @@ internal class PotentialTokenState<TTokenType>(
 
     public EndOfTokenState<TTokenType> EndOfTokenStateInstance => _endOfTokenStateInstance;
 
-    protected override bool TryGetNextState(char c, out IState<TTokenType> nextState)
+    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
     {
         if (base.TryGetNextState(c, out nextState))
             return true;

--- a/Tokensharp/StateMachine/SingleStateLookup.cs
+++ b/Tokensharp/StateMachine/SingleStateLookup.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Tokensharp.StateMachine;
+
+internal class SingleStateLookup<TTokenType>(char character, State<TTokenType> state) : IStateLookup<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
+{
+    public bool TryGetState(in char c, [NotNullWhen(true)] out IState<TTokenType>? result)
+    {
+        if (c == character)
+        {
+            result = state;
+            return true;
+        }
+        
+        result = null;
+        return false;
+    }
+}

--- a/Tokensharp/StateMachine/StartOfCheckForTokenState.cs
+++ b/Tokensharp/StateMachine/StartOfCheckForTokenState.cs
@@ -4,7 +4,7 @@ namespace Tokensharp.StateMachine;
 
 internal class StartOfCheckForTokenState<TTokenType>(
     ITokenTreeNode<TTokenType> node,
-    State<TTokenType> fallback,
+    IState<TTokenType> fallback,
     IEndOfTokenStateAccessor<TTokenType> fallbackStateEndOfTokenStateAccessor,
     IStateCharacterCheck fallbackStateCharacterCheck)
     : CheckForTokenState<TTokenType>(node, fallback, fallbackStateEndOfTokenStateAccessor, fallbackStateCharacterCheck) 
@@ -18,7 +18,7 @@ internal class StartOfCheckForTokenState<TTokenType>(
 
     public new static StartOfCheckForTokenState<TTokenType> For(
         ITokenTreeNode<TTokenType> node,
-        State<TTokenType> fallbackState,
+        IState<TTokenType> fallbackState,
         IEndOfTokenStateAccessor<TTokenType> fallbackStateEndOfTokenStateAccessor,
         IStateCharacterCheck fallbackStateCharacterCheck)
     {

--- a/Tokensharp/StateMachine/StartState.cs
+++ b/Tokensharp/StateMachine/StartState.cs
@@ -23,10 +23,10 @@ internal class StartState<TTokenType>(
         return false;
     }
 
-    public static StartState<TTokenType> For(ITokenTreeNode<TTokenType> tokenTreeNode, bool textAndNumbersAreText)
+    public static StartState<TTokenType> For(ITokenTreeNode<TTokenType> tokenTreeNode, bool numbersAreText)
     {
         ITextWhiteSpaceNumberLookup<TTokenType> textWhiteSpaceNumberLookup;
-        if (textAndNumbersAreText)
+        if (numbersAreText)
         {
             textWhiteSpaceNumberLookup = new TextAndNumberAsTextLookup<TTokenType>(tokenTreeNode);
         }

--- a/Tokensharp/StateMachine/StartState.cs
+++ b/Tokensharp/StateMachine/StartState.cs
@@ -11,7 +11,7 @@ internal class StartState<TTokenType>(
     : NodeStateBase<TTokenType>(rootNode.RootNode)
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    protected override bool TryGetNextState(char c, out IState<TTokenType> nextState)
+    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
     {
         if (base.TryGetNextState(c, out nextState))
             return true;

--- a/Tokensharp/StateMachine/State.cs
+++ b/Tokensharp/StateMachine/State.cs
@@ -6,9 +6,9 @@ internal abstract class State<TTokenType> : IState<TTokenType> where TTokenType 
 {
     public abstract bool IsEndOfToken { get; }
 
-    public virtual bool TryTransition(char c, ref StateMachineContext context, out IState<TTokenType> nextState)
+    public virtual bool TryTransition(in char c, ref StateMachineContext context, out IState<TTokenType> nextState)
     {
-        if (!TryGetNextState(c, out nextState) &&
+        if (!TryGetNextState(in c, out nextState) &&
             !TryGetDefaultState(out nextState))
             return false;
         
@@ -16,7 +16,7 @@ internal abstract class State<TTokenType> : IState<TTokenType> where TTokenType 
         return !nextState.IsEndOfToken;
     }
 
-    protected abstract bool TryGetNextState(char c, out IState<TTokenType> nextState);
+    protected abstract bool TryGetNextState(in char c, out IState<TTokenType> nextState);
 
     public virtual bool TryDefaultTransition(ref StateMachineContext context, out IState<TTokenType> defaultState)
     {

--- a/Tokensharp/StateMachine/StateLookupBuilder.cs
+++ b/Tokensharp/StateMachine/StateLookupBuilder.cs
@@ -19,6 +19,12 @@ internal class StateLookupBuilder<TTokenType> where TTokenType : TokenType<TToke
         if (_states.Count == 0)
             return _noStatesLookup;
 
+        if (_states.Count == 1)
+        {
+            (char character, State<TTokenType> state) = _states.First();
+            return new SingleStateLookup<TTokenType>(character, state);
+        }
+
         var swiftStateBuilder = new Dictionary<char, IState<TTokenType>>();
 
         foreach ((char character, State<TTokenType> state) in _states)
@@ -29,7 +35,7 @@ internal class StateLookupBuilder<TTokenType> where TTokenType : TokenType<TToke
 
     private class AlwaysFalseLookup : IStateLookup<TTokenType>
     {
-        public bool TryGetState(char c, [NotNullWhen(true)] out IState<TTokenType>? state)
+        public bool TryGetState(in char c, [NotNullWhen(true)] out IState<TTokenType>? state)
         {
             state = null;
             return false;

--- a/Tokensharp/StateMachine/TextAndNumberAsTextLookup.cs
+++ b/Tokensharp/StateMachine/TextAndNumberAsTextLookup.cs
@@ -1,0 +1,27 @@
+﻿using Tokensharp.TokenTree;
+
+namespace Tokensharp.StateMachine;
+
+internal class TextAndNumberAsTextLookup<TTokenType> : TextWhiteSpaceNumberLookupBase<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
+{
+    private readonly WhiteSpace<TTokenType> _whiteSpaceState;
+    private readonly TextAndNumberAsTextState<TTokenType> _textAndNumberAsTextState;
+
+    public TextAndNumberAsTextLookup(ITokenTreeNode<TTokenType> tokenTreeNode)
+    {
+        _whiteSpaceState = new WhiteSpace<TTokenType>(tokenTreeNode);
+        _textAndNumberAsTextState = new TextAndNumberAsTextState<TTokenType>(tokenTreeNode);
+
+        IStateLookup<TTokenType> compiledTextWhiteSpaceNumberStates = BuildStateLookup(tokenTreeNode);
+
+        _whiteSpaceState.StateLookup = compiledTextWhiteSpaceNumberStates;
+        _textAndNumberAsTextState.StateLookup = compiledTextWhiteSpaceNumberStates;
+    }
+
+    public override TextWhiteSpaceNumberBase<TTokenType> GetState(in char c)
+    {
+        if (char.IsWhiteSpace(c))
+            return _whiteSpaceState;
+        return _textAndNumberAsTextState;
+    }
+}

--- a/Tokensharp/StateMachine/TextAndNumberAsTextState.cs
+++ b/Tokensharp/StateMachine/TextAndNumberAsTextState.cs
@@ -2,9 +2,9 @@
 
 namespace Tokensharp.StateMachine;
 
-internal class Text<TTokenType>(ITokenTreeNode<TTokenType> rootNode) 
+internal class TextAndNumberAsTextState<TTokenType>(ITokenTreeNode<TTokenType> rootNode) 
     : TextWhiteSpaceNumberBase<TTokenType>(rootNode, TokenType<TTokenType>.Text)
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    public override bool CharacterIsValidForState(in char c) => !char.IsWhiteSpace(c) && !char.IsDigit(c);
+    public override bool CharacterIsValidForState(in char c) => !char.IsWhiteSpace(c);
 }

--- a/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
+++ b/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Tokensharp.TokenTree;
 
 namespace Tokensharp.StateMachine;
@@ -30,5 +29,5 @@ internal abstract class TextWhiteSpaceNumberBase<TTokenType>(ITokenTreeNode<TTok
         return true;
     }
 
-    public abstract bool CharacterIsValidForState(char c);
+    public abstract bool CharacterIsValidForState(in char c);
 }

--- a/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
+++ b/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
@@ -10,13 +10,13 @@ internal abstract class TextWhiteSpaceNumberBase<TTokenType>(ITokenTreeNode<TTok
     private readonly EndOfTokenState<TTokenType> _endOfTokenStateInstance = new(tokenType);
     public EndOfTokenState<TTokenType> EndOfTokenStateInstance => _endOfTokenStateInstance;
 
-    protected override bool TryGetNextState(char c, out IState<TTokenType> nextState)
+    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
     {
         if (!CharacterIsValidForState(c))
         {
             nextState = EndOfTokenStateInstance;
         }
-        else if (!base.TryGetNextState(c, out nextState))
+        else if (!base.TryGetNextState(in c, out nextState))
         {
             nextState = this;
         }

--- a/Tokensharp/StateMachine/TextWhiteSpaceNumberLookup.cs
+++ b/Tokensharp/StateMachine/TextWhiteSpaceNumberLookup.cs
@@ -1,0 +1,32 @@
+﻿using Tokensharp.TokenTree;
+
+namespace Tokensharp.StateMachine;
+
+internal class TextWhiteSpaceNumberLookup<TTokenType> : TextWhiteSpaceNumberLookupBase<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
+{
+    private readonly WhiteSpace<TTokenType> _whiteSpaceState;
+    private readonly Number<TTokenType> _numberState;
+    private readonly Text<TTokenType> _textState;
+
+    public TextWhiteSpaceNumberLookup(ITokenTreeNode<TTokenType> tokenTreeNode)
+    {
+        _whiteSpaceState = new WhiteSpace<TTokenType>(tokenTreeNode);
+        _numberState = new Number<TTokenType>(tokenTreeNode);
+        _textState = new Text<TTokenType>(tokenTreeNode);
+
+        IStateLookup<TTokenType> compiledTextWhiteSpaceNumberStates = BuildStateLookup(tokenTreeNode);
+
+        _whiteSpaceState.StateLookup = compiledTextWhiteSpaceNumberStates;
+        _numberState.StateLookup = compiledTextWhiteSpaceNumberStates;
+        _textState.StateLookup = compiledTextWhiteSpaceNumberStates;
+    }
+
+    public override TextWhiteSpaceNumberBase<TTokenType> GetState(in char c)
+    {
+        if (char.IsWhiteSpace(c))
+            return _whiteSpaceState;
+        if (char.IsDigit(c))
+            return _numberState;
+        return _textState;
+    }
+}

--- a/Tokensharp/StateMachine/TextWhiteSpaceNumberLookupBase.cs
+++ b/Tokensharp/StateMachine/TextWhiteSpaceNumberLookupBase.cs
@@ -1,0 +1,33 @@
+﻿using Tokensharp.TokenTree;
+
+namespace Tokensharp.StateMachine;
+
+internal abstract class TextWhiteSpaceNumberLookupBase<TTokenType> : ITextWhiteSpaceNumberLookup<TTokenType>
+    where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
+{
+
+    protected IStateLookup<TTokenType> BuildStateLookup(ITokenTreeNode<TTokenType> tokenTreeNode)
+    {
+        var textWhiteSpaceNumberStates = new StateLookupBuilder<TTokenType>();
+
+        foreach (ITokenTreeNode<TTokenType> startNode in tokenTreeNode.RootNode)
+        {
+            TextWhiteSpaceNumberBase<TTokenType> fallback = GetState(startNode.Character);
+
+            if (startNode.IsEndOfToken)
+            {
+                textWhiteSpaceNumberStates.Add(startNode.Character,
+                    fallback.EndOfTokenStateInstance);
+            }
+            else
+            {
+                textWhiteSpaceNumberStates.Add(startNode.Character,
+                    StartOfCheckForTokenState<TTokenType>.For(startNode, fallback, fallback, fallback));
+            }
+        }
+
+        return textWhiteSpaceNumberStates.Build();
+    }
+
+    public abstract TextWhiteSpaceNumberBase<TTokenType> GetState(in char c);
+}

--- a/Tokensharp/StateMachine/WhiteSpace.cs
+++ b/Tokensharp/StateMachine/WhiteSpace.cs
@@ -1,4 +1,4 @@
-using Tokensharp.TokenTree;
+﻿using Tokensharp.TokenTree;
 
 namespace Tokensharp.StateMachine;
 
@@ -6,5 +6,5 @@ internal class WhiteSpace<TTokenType>(ITokenTreeNode<TTokenType> rootNode)
     : TextWhiteSpaceNumberBase<TTokenType>(rootNode, TokenType<TTokenType>.WhiteSpace)
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    public override bool CharacterIsValidForState(char c) => char.IsWhiteSpace(c);
+    public override bool CharacterIsValidForState(in char c) => char.IsWhiteSpace(c);
 }

--- a/Tokensharp/TokenConfiguration.cs
+++ b/Tokensharp/TokenConfiguration.cs
@@ -6,16 +6,16 @@ namespace Tokensharp;
 public sealed class TokenConfiguration<TTokenType> : ITokenConfiguration<TTokenType>
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    internal TokenConfiguration(IEnumerable<LexemeToTokenType<TTokenType>> lexemeToTokenTypes, bool textAndNumbersAreText = false)
+    internal TokenConfiguration(IEnumerable<LexemeToTokenType<TTokenType>> lexemeToTokenTypes, bool numbersAreText = false)
     {
         ITokenTreeNode<TTokenType> tokenTree = lexemeToTokenTypes.ToTokenTree();
         
-        StartState = StartState<TTokenType>.For(tokenTree, textAndNumbersAreText);
+        StartState = StartState<TTokenType>.For(tokenTree, numbersAreText);
         
-        TextAndNumbersAreText = textAndNumbersAreText;
+        NumbersAreText = numbersAreText;
     }
 
-    public bool TextAndNumbersAreText { get; }
+    public bool NumbersAreText { get; }
     
     public static implicit operator TokenConfiguration<TTokenType>(LexemeToTokenType<TTokenType>[] lexemeToTokenTypes)
     {

--- a/Tokensharp/TokenConfiguration.cs
+++ b/Tokensharp/TokenConfiguration.cs
@@ -1,24 +1,26 @@
-﻿using System.Collections;
-using Tokensharp.StateMachine;
+﻿using Tokensharp.StateMachine;
 using Tokensharp.TokenTree;
 
 namespace Tokensharp;
 
-public class TokenConfiguration<TTokenType> : ITokenConfiguration<TTokenType>
+public sealed class TokenConfiguration<TTokenType> : ITokenConfiguration<TTokenType>
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    internal TokenConfiguration(IEnumerable<LexemeToTokenType<TTokenType>> lexemeToTokenTypes)
+    internal TokenConfiguration(IEnumerable<LexemeToTokenType<TTokenType>> lexemeToTokenTypes, bool textAndNumbersAreText = false)
     {
-        TokenTree = lexemeToTokenTypes.ToTokenTree();
-        StartState = StartState<TTokenType>.For(TokenTree);
+        ITokenTreeNode<TTokenType> tokenTree = lexemeToTokenTypes.ToTokenTree();
+        
+        StartState = StartState<TTokenType>.For(tokenTree, textAndNumbersAreText);
+        
+        TextAndNumbersAreText = textAndNumbersAreText;
     }
+
+    public bool TextAndNumbersAreText { get; }
     
     public static implicit operator TokenConfiguration<TTokenType>(LexemeToTokenType<TTokenType>[] lexemeToTokenTypes)
     {
         return new TokenConfiguration<TTokenType>(lexemeToTokenTypes);
     }
-
-    internal ITokenTreeNode<TTokenType> TokenTree { get; }
     
     internal StartState<TTokenType> StartState { get; }
 }

--- a/Tokensharp/TokenConfigurationBuilder.cs
+++ b/Tokensharp/TokenConfigurationBuilder.cs
@@ -35,13 +35,13 @@ public class TokenConfigurationBuilder<TTokenType> : IEnumerable<TTokenType>
             throw new DuplicateLexemeException(tokenType.Identifier);
     }
 
-    public bool TextAndNumbersAreText { get; set; } = false;
+    public bool NumbersAreText { get; set; } = false;
 
     public bool LexemeConfigured(string lexeme) => _tokenDefinitions.ContainsKey(lexeme);
     
     public TokenConfiguration<TTokenType> Build()
     {
-        return new TokenConfiguration<TTokenType>(_tokenDefinitions.Select(kv => new LexemeToTokenType<TTokenType>(kv.Key, kv.Value)), TextAndNumbersAreText);
+        return new TokenConfiguration<TTokenType>(_tokenDefinitions.Select(kv => new LexemeToTokenType<TTokenType>(kv.Key, kv.Value)), NumbersAreText);
     }
 
     public IEnumerator<TTokenType> GetEnumerator()

--- a/Tokensharp/TokenConfigurationBuilder.cs
+++ b/Tokensharp/TokenConfigurationBuilder.cs
@@ -7,7 +7,7 @@ public class TokenConfigurationBuilder<TTokenType> : IEnumerable<TTokenType>
 {
     private readonly Dictionary<string, TTokenType> _tokenDefinitions = new();
 
-    public TokenConfigurationBuilder() : this([])
+    public TokenConfigurationBuilder() : this(Array.Empty<LexemeToTokenType<TTokenType>>())
     {
     }
 
@@ -15,6 +15,12 @@ public class TokenConfigurationBuilder<TTokenType> : IEnumerable<TTokenType>
     {
         foreach (TTokenType tokenType in tokenTypes)
             Add(tokenType);
+    }
+
+    public TokenConfigurationBuilder(IEnumerable<LexemeToTokenType<TTokenType>> lexemesToTokens)
+    {
+        foreach (LexemeToTokenType<TTokenType> lexemeToToken in lexemesToTokens)
+            Add(lexemeToToken);
     }
     
     public TTokenType this[string lexeme]
@@ -33,6 +39,11 @@ public class TokenConfigurationBuilder<TTokenType> : IEnumerable<TTokenType>
     {
         if (!_tokenDefinitions.TryAdd(tokenType.Identifier, tokenType))
             throw new DuplicateLexemeException(tokenType.Identifier);
+    }
+
+    public void Add(LexemeToTokenType<TTokenType> lexemeToTokenType)
+    {
+        Add(lexemeToTokenType.Lexeme, lexemeToTokenType.TokenType);
     }
 
     public bool NumbersAreText { get; set; } = false;

--- a/Tokensharp/TokenConfigurationBuilder.cs
+++ b/Tokensharp/TokenConfigurationBuilder.cs
@@ -35,9 +35,14 @@ public class TokenConfigurationBuilder<TTokenType> : IEnumerable<TTokenType>
             throw new DuplicateLexemeException(tokenType.Identifier);
     }
 
+    public bool TextAndNumbersAreText { get; set; } = false;
+
     public bool LexemeConfigured(string lexeme) => _tokenDefinitions.ContainsKey(lexeme);
     
-    public TokenConfiguration<TTokenType> Build() => new(_tokenDefinitions.Select(kv => new LexemeToTokenType<TTokenType>(kv.Key, kv.Value)));
+    public TokenConfiguration<TTokenType> Build()
+    {
+        return new TokenConfiguration<TTokenType>(_tokenDefinitions.Select(kv => new LexemeToTokenType<TTokenType>(kv.Key, kv.Value)), TextAndNumbersAreText);
+    }
 
     public IEnumerator<TTokenType> GetEnumerator()
     {

--- a/Tokensharp/Tokensharp.csproj
+++ b/Tokensharp/Tokensharp.csproj
@@ -9,7 +9,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>4.4.0</Version>
+        <Version>4.5.0</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 


### PR DESCRIPTION
### Description

This pull request introduces the ability to treat numbers as text tokens in the `CsvTokenTypes` configuration. Key changes include:

- Added `NumbersAreText` support in `CsvTokenTypes` to enable treating numeric values as text.
- Updated related tests (`CsvTests`, `NumbersAsTextTests`) to validate this behavior.
- Introduced `TextAndNumberAsTextLookup` and `ITextWhiteSpaceNumberLookup` strategies, optimizing state resolution for number handling.
- Enhanced `TokenConfigurationBuilder`, allowing configuration of `LexemeToTokenType` and expanded number parsing options.
- Refactored state machine classes to use `in` modifier for `char` parameters, improving efficiency.
- Introduced `SingleStateLookup` for optimized state transitions in single-character paths.