### PR TITLE
Refactor state machine initialization and `TryGetNextState` logic

### DIFF
--- a/Tokensharp/StateMachine/CheckForTokenState.cs
+++ b/Tokensharp/StateMachine/CheckForTokenState.cs
@@ -23,7 +23,7 @@ internal class CheckForTokenState<TTokenType>(
     {
         Debug.Assert(!Node.IsEndOfToken);
         
-        if (base.TryGetNextState(c, out nextState))
+        if (StateLookup.TryGetState(c, out nextState!))
             return true;
         
         if (fallbackStateCharacterCheck.CharacterIsValidForState(c))

--- a/Tokensharp/StateMachine/NodeStateBase.cs
+++ b/Tokensharp/StateMachine/NodeStateBase.cs
@@ -9,10 +9,10 @@ internal abstract class NodeStateBase<TTokenType>(ITokenTreeNode<TTokenType> nod
     
     protected ITokenTreeNode<TTokenType> Node { get; } = node;
 
-    internal IStateLookup<TTokenType> StateLookup
+    protected IStateLookup<TTokenType> StateLookup
     {
         get => field ?? throw new InvalidOperationException("StateLookup not initialized");
-        set;
+        init;
     }
 
     public override string ToString()

--- a/Tokensharp/StateMachine/NodeStateBase.cs
+++ b/Tokensharp/StateMachine/NodeStateBase.cs
@@ -9,17 +9,10 @@ internal abstract class NodeStateBase<TTokenType>(ITokenTreeNode<TTokenType> nod
     
     protected ITokenTreeNode<TTokenType> Node { get; } = node;
 
-    private IStateLookup<TTokenType>? _stateLookup;
-    
-    internal IStateLookup<TTokenType> StateLookup { set => _stateLookup = value; }
-
-    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
+    internal IStateLookup<TTokenType> StateLookup
     {
-        if (_stateLookup!.TryGetState(c, out nextState!))
-            return true;
-
-        nextState = null!;
-        return false;
+        get => field ?? throw new InvalidOperationException("StateLookup not initialized");
+        set;
     }
 
     public override string ToString()

--- a/Tokensharp/StateMachine/PotentialTokenState.cs
+++ b/Tokensharp/StateMachine/PotentialTokenState.cs
@@ -18,7 +18,7 @@ internal class PotentialTokenState<TTokenType>(
 
     protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
     {
-        if (base.TryGetNextState(c, out nextState))
+        if (StateLookup.TryGetState(c, out nextState!))
             return true;
 
         if (Node.IsEndOfToken || !fallbackStateCharacterCheck.CharacterIsValidForState(c))

--- a/Tokensharp/StateMachine/SingleStateLookup.cs
+++ b/Tokensharp/StateMachine/SingleStateLookup.cs
@@ -2,7 +2,7 @@
 
 namespace Tokensharp.StateMachine;
 
-internal class SingleStateLookup<TTokenType>(char character, State<TTokenType> state) : IStateLookup<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
+internal class SingleStateLookup<TTokenType>(char character, IState<TTokenType> state) : IStateLookup<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
     public bool TryGetState(in char c, [NotNullWhen(true)] out IState<TTokenType>? result)
     {

--- a/Tokensharp/StateMachine/StartState.cs
+++ b/Tokensharp/StateMachine/StartState.cs
@@ -2,44 +2,22 @@ using Tokensharp.TokenTree;
 
 namespace Tokensharp.StateMachine;
 
-internal class StartState<TTokenType>(
-    ITokenTreeNode<TTokenType> rootNode,
-    ITextWhiteSpaceNumberLookup<TTokenType> textWhiteSpaceNumberLookup)
-    : NodeStateBase<TTokenType>(rootNode.RootNode)
+internal class StartState<TTokenType> : NodeStateBase<TTokenType>
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
-    {
-        if (StateLookup.TryGetState(c, out nextState!))
-            return true;
+    private readonly ITextWhiteSpaceNumberLookup<TTokenType> _textWhiteSpaceNumberLookup;
 
-        nextState = textWhiteSpaceNumberLookup.GetState(in c);
-        return true;
-    }
-
-    protected override bool TryGetDefaultState(out IState<TTokenType> defaultState)
+    public StartState(ITokenTreeNode<TTokenType> tokenTreeNode, bool numbersAreText) : base(tokenTreeNode.RootNode)
     {
-        defaultState = this;
-        return false;
-    }
-
-    public static StartState<TTokenType> For(ITokenTreeNode<TTokenType> tokenTreeNode, bool numbersAreText)
-    {
-        ITextWhiteSpaceNumberLookup<TTokenType> textWhiteSpaceNumberLookup;
-        if (numbersAreText)
-        {
-            textWhiteSpaceNumberLookup = new TextAndNumberAsTextLookup<TTokenType>(tokenTreeNode);
-        }
-        else
-        {
-            textWhiteSpaceNumberLookup = new TextWhiteSpaceNumberLookup<TTokenType>(tokenTreeNode);
-        }
+        _textWhiteSpaceNumberLookup = numbersAreText
+            ? new TextAndNumberAsTextLookup<TTokenType>(tokenTreeNode)
+            : new TextWhiteSpaceNumberLookup<TTokenType>(tokenTreeNode);
 
         var startStates = new StateLookupBuilder<TTokenType>();
 
         foreach (ITokenTreeNode<TTokenType> startNode in tokenTreeNode.RootNode)
         {
-            TextWhiteSpaceNumberBase<TTokenType> fallback = textWhiteSpaceNumberLookup.GetState(startNode.Character);
+            TextWhiteSpaceNumberBase<TTokenType> fallback = _textWhiteSpaceNumberLookup.GetState(startNode.Character);
             
             if (startNode.HasChildren)
             {
@@ -50,12 +28,22 @@ internal class StartState<TTokenType>(
                 startStates.Add(startNode.Character, new EndOfSingleCharacterTokenState<TTokenType>(startNode.TokenType));
             }
         }
-
-        var startState = new StartState<TTokenType>(tokenTreeNode.RootNode, textWhiteSpaceNumberLookup)
-        {
-            StateLookup = startStates.Build()
-        };
         
-        return startState;
+        StateLookup = startStates.Build();
+    }
+
+    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
+    {
+        if (StateLookup.TryGetState(c, out nextState!))
+            return true;
+
+        nextState = _textWhiteSpaceNumberLookup.GetState(in c);
+        return true;
+    }
+
+    protected override bool TryGetDefaultState(out IState<TTokenType> defaultState)
+    {
+        defaultState = this;
+        return false;
     }
 }

--- a/Tokensharp/StateMachine/StartState.cs
+++ b/Tokensharp/StateMachine/StartState.cs
@@ -10,7 +10,7 @@ internal class StartState<TTokenType>(
 {
     protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
     {
-        if (base.TryGetNextState(c, out nextState))
+        if (StateLookup.TryGetState(c, out nextState!))
             return true;
 
         nextState = textWhiteSpaceNumberLookup.GetState(in c);

--- a/Tokensharp/StateMachine/StateLookupBuilder.cs
+++ b/Tokensharp/StateMachine/StateLookupBuilder.cs
@@ -5,7 +5,7 @@ namespace Tokensharp.StateMachine;
 
 internal class StateLookupBuilder<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    private readonly Dictionary<char, State<TTokenType>> _states = new();
+    private readonly Dictionary<char, IState<TTokenType>> _states = new();
     
     private readonly AlwaysFalseLookup _noStatesLookup = new();
 
@@ -21,16 +21,11 @@ internal class StateLookupBuilder<TTokenType> where TTokenType : TokenType<TToke
 
         if (_states.Count == 1)
         {
-            (char character, State<TTokenType> state) = _states.First();
+            (char character, IState<TTokenType> state) = _states.First();
             return new SingleStateLookup<TTokenType>(character, state);
         }
 
-        var swiftStateBuilder = new Dictionary<char, IState<TTokenType>>();
-
-        foreach ((char character, State<TTokenType> state) in _states)
-            swiftStateBuilder.Add(character, state);
-
-        return new MultipleStateLookup<TTokenType>(swiftStateBuilder.ToFrozenDictionary());
+        return new MultipleStateLookup<TTokenType>(_states.ToFrozenDictionary());
     }
 
     private class AlwaysFalseLookup : IStateLookup<TTokenType>

--- a/Tokensharp/StateMachine/TextAndNumberAsTextLookup.cs
+++ b/Tokensharp/StateMachine/TextAndNumberAsTextLookup.cs
@@ -2,21 +2,12 @@
 
 namespace Tokensharp.StateMachine;
 
-internal class TextAndNumberAsTextLookup<TTokenType> : TextWhiteSpaceNumberLookupBase<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
+internal class TextAndNumberAsTextLookup<TTokenType>(ITokenTreeNode<TTokenType> tokenTreeNode)
+    : TextWhiteSpaceNumberLookupBase<TTokenType>
+    where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    private readonly WhiteSpace<TTokenType> _whiteSpaceState;
-    private readonly TextAndNumberAsTextState<TTokenType> _textAndNumberAsTextState;
-
-    public TextAndNumberAsTextLookup(ITokenTreeNode<TTokenType> tokenTreeNode)
-    {
-        _whiteSpaceState = new WhiteSpace<TTokenType>(tokenTreeNode);
-        _textAndNumberAsTextState = new TextAndNumberAsTextState<TTokenType>(tokenTreeNode);
-
-        IStateLookup<TTokenType> compiledTextWhiteSpaceNumberStates = BuildStateLookup(tokenTreeNode);
-
-        _whiteSpaceState.StateLookup = compiledTextWhiteSpaceNumberStates;
-        _textAndNumberAsTextState.StateLookup = compiledTextWhiteSpaceNumberStates;
-    }
+    private readonly WhiteSpace<TTokenType> _whiteSpaceState = new(tokenTreeNode);
+    private readonly TextAndNumberAsTextState<TTokenType> _textAndNumberAsTextState = new(tokenTreeNode);
 
     public override TextWhiteSpaceNumberBase<TTokenType> GetState(in char c)
     {

--- a/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
+++ b/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
@@ -2,26 +2,25 @@ using Tokensharp.TokenTree;
 
 namespace Tokensharp.StateMachine;
 
-internal abstract class TextWhiteSpaceNumberBase<TTokenType>(ITokenTreeNode<TTokenType> rootNode, TTokenType tokenType)
-    : NodeStateBase<TTokenType>(rootNode.RootNode), IEndOfTokenStateAccessor<TTokenType>, IStateCharacterCheck
+internal abstract class TextWhiteSpaceNumberBase<TTokenType> : NodeStateBase<TTokenType>, IEndOfTokenStateAccessor<TTokenType>, IStateCharacterCheck
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    private readonly EndOfTokenState<TTokenType> _endOfTokenStateInstance = new(tokenType);
+    private readonly EndOfTokenState<TTokenType> _endOfTokenStateInstance;
+
+    protected TextWhiteSpaceNumberBase(ITokenTreeNode<TTokenType> rootNode, TTokenType tokenType) : base(rootNode.RootNode)
+    {
+        _endOfTokenStateInstance = new EndOfTokenState<TTokenType>(tokenType);
+        StateLookup = BuildStateLookup(rootNode);
+    }
+
     public EndOfTokenState<TTokenType> EndOfTokenStateInstance => _endOfTokenStateInstance;
 
     protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
     {
-        if (CharacterIsValidForState(c))
-        {
-            if (StateLookup.TryGetState(in c, out nextState!))
-                return true;
-            
-            nextState = this;
-        }
-        else
-        {
-            nextState = _endOfTokenStateInstance;
-        }
+        if (StateLookup.TryGetState(in c, out nextState!))
+            return true;
+
+        nextState = CharacterIsValidForState(c) ? this : _endOfTokenStateInstance;
 
         return true;
     }
@@ -30,6 +29,30 @@ internal abstract class TextWhiteSpaceNumberBase<TTokenType>(ITokenTreeNode<TTok
     {
         defaultState = _endOfTokenStateInstance;
         return true;
+    }
+
+    private IStateLookup<TTokenType> BuildStateLookup(ITokenTreeNode<TTokenType> tokenTreeNode)
+    {
+        var textWhiteSpaceNumberStates = new StateLookupBuilder<TTokenType>();
+
+        foreach (ITokenTreeNode<TTokenType> startNode in tokenTreeNode.RootNode)
+        {
+            if (!CharacterIsValidForState(startNode.Character))
+                continue;
+
+            if (startNode.IsEndOfToken)
+            {
+                textWhiteSpaceNumberStates.Add(startNode.Character,
+                    EndOfTokenStateInstance);
+            }
+            else
+            {
+                textWhiteSpaceNumberStates.Add(startNode.Character,
+                    StartOfCheckForTokenState<TTokenType>.For(startNode, this, this, this));
+            }
+        }
+
+        return textWhiteSpaceNumberStates.Build();
     }
 
     public abstract bool CharacterIsValidForState(in char c);

--- a/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
+++ b/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
@@ -11,13 +11,16 @@ internal abstract class TextWhiteSpaceNumberBase<TTokenType>(ITokenTreeNode<TTok
 
     protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
     {
-        if (!CharacterIsValidForState(c))
+        if (CharacterIsValidForState(c))
         {
-            nextState = EndOfTokenStateInstance;
-        }
-        else if (!base.TryGetNextState(in c, out nextState))
-        {
+            if (StateLookup.TryGetState(in c, out nextState!))
+                return true;
+            
             nextState = this;
+        }
+        else
+        {
+            nextState = _endOfTokenStateInstance;
         }
 
         return true;

--- a/Tokensharp/StateMachine/TextWhiteSpaceNumberLookup.cs
+++ b/Tokensharp/StateMachine/TextWhiteSpaceNumberLookup.cs
@@ -2,24 +2,13 @@
 
 namespace Tokensharp.StateMachine;
 
-internal class TextWhiteSpaceNumberLookup<TTokenType> : TextWhiteSpaceNumberLookupBase<TTokenType> where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
+internal class TextWhiteSpaceNumberLookup<TTokenType>(ITokenTreeNode<TTokenType> tokenTreeNode)
+    : TextWhiteSpaceNumberLookupBase<TTokenType>
+    where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    private readonly WhiteSpace<TTokenType> _whiteSpaceState;
-    private readonly Number<TTokenType> _numberState;
-    private readonly Text<TTokenType> _textState;
-
-    public TextWhiteSpaceNumberLookup(ITokenTreeNode<TTokenType> tokenTreeNode)
-    {
-        _whiteSpaceState = new WhiteSpace<TTokenType>(tokenTreeNode);
-        _numberState = new Number<TTokenType>(tokenTreeNode);
-        _textState = new Text<TTokenType>(tokenTreeNode);
-
-        IStateLookup<TTokenType> compiledTextWhiteSpaceNumberStates = BuildStateLookup(tokenTreeNode);
-
-        _whiteSpaceState.StateLookup = compiledTextWhiteSpaceNumberStates;
-        _numberState.StateLookup = compiledTextWhiteSpaceNumberStates;
-        _textState.StateLookup = compiledTextWhiteSpaceNumberStates;
-    }
+    private readonly WhiteSpace<TTokenType> _whiteSpaceState = new(tokenTreeNode);
+    private readonly Number<TTokenType> _numberState = new(tokenTreeNode);
+    private readonly Text<TTokenType> _textState = new(tokenTreeNode);
 
     public override TextWhiteSpaceNumberBase<TTokenType> GetState(in char c)
     {

--- a/Tokensharp/StateMachine/TextWhiteSpaceNumberLookupBase.cs
+++ b/Tokensharp/StateMachine/TextWhiteSpaceNumberLookupBase.cs
@@ -1,33 +1,7 @@
-﻿using Tokensharp.TokenTree;
-
-namespace Tokensharp.StateMachine;
+﻿namespace Tokensharp.StateMachine;
 
 internal abstract class TextWhiteSpaceNumberLookupBase<TTokenType> : ITextWhiteSpaceNumberLookup<TTokenType>
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-
-    protected IStateLookup<TTokenType> BuildStateLookup(ITokenTreeNode<TTokenType> tokenTreeNode)
-    {
-        var textWhiteSpaceNumberStates = new StateLookupBuilder<TTokenType>();
-
-        foreach (ITokenTreeNode<TTokenType> startNode in tokenTreeNode.RootNode)
-        {
-            TextWhiteSpaceNumberBase<TTokenType> fallback = GetState(startNode.Character);
-
-            if (startNode.IsEndOfToken)
-            {
-                textWhiteSpaceNumberStates.Add(startNode.Character,
-                    fallback.EndOfTokenStateInstance);
-            }
-            else
-            {
-                textWhiteSpaceNumberStates.Add(startNode.Character,
-                    StartOfCheckForTokenState<TTokenType>.For(startNode, fallback, fallback, fallback));
-            }
-        }
-
-        return textWhiteSpaceNumberStates.Build();
-    }
-
     public abstract TextWhiteSpaceNumberBase<TTokenType> GetState(in char c);
 }

--- a/Tokensharp/TokenConfiguration.cs
+++ b/Tokensharp/TokenConfiguration.cs
@@ -10,7 +10,7 @@ public sealed class TokenConfiguration<TTokenType> : ITokenConfiguration<TTokenT
     {
         ITokenTreeNode<TTokenType> tokenTree = lexemeToTokenTypes.ToTokenTree();
         
-        StartState = StartState<TTokenType>.For(tokenTree, numbersAreText);
+        StartState = new StartState<TTokenType>(tokenTree, numbersAreText);
         
         NumbersAreText = numbersAreText;
     }

--- a/Tokensharp/Tokensharp.csproj
+++ b/Tokensharp/Tokensharp.csproj
@@ -9,7 +9,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>4.5.0</Version>
+        <Version>4.5.1</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 


### PR DESCRIPTION
### Description

This pull request refactors the internal state management logic of the `TextWhiteSpaceNumberBase` class for improved clarity and efficiency. The following changes are included:

- Moved the `StateLookup` initialization from `TextWhiteSpaceNumberLookupBase` to `TextWhiteSpaceNumberBase`, ensuring `StateLookup` is built internally rather than relying on external assignment.
- Marked `NodeStateBase.StateLookup` as `init` only, improving immutability.
- Modified related components (`StateLookupBuilder`, `SingleStateLookup`, etc.) to accept `IState<TTokenType>` instead of `State<TTokenType>`.
- Simplified `TextWhiteSpaceNumberBase.TryGetNextState` and removed its dependency on the base method in `NodeStateBase`.
- Removed `TryGetNextState` from `NodeStateBase` and inlined lookup checks for direct interaction with `StateLookup`.

These changes enhance encapsulation, reduce coupling between components, and streamline state transition logic.