### PR TITLE
Refactor state transitions and simplify state instantiation

### DIFF
--- a/Tokensharp/StateMachine/CheckForTokenState.cs
+++ b/Tokensharp/StateMachine/CheckForTokenState.cs
@@ -3,21 +3,43 @@ using Tokensharp.TokenTree;
 
 namespace Tokensharp.StateMachine;
 
-internal class CheckForTokenState<TTokenType>(
-    ITokenTreeNode<TTokenType> node,
-    IState<TTokenType> fallback,
-    IEndOfTokenStateAccessor<TTokenType> fallbackStateEndOfTokenStateAccessor,
-    IStateCharacterCheck fallbackStateCharacterCheck)
-    : NodeStateBase<TTokenType>(node), IEndOfTokenStateAccessor<TTokenType>
+internal class CheckForTokenState<TTokenType> : NodeStateBase<TTokenType>, IEndOfTokenStateAccessor<TTokenType>
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    private readonly FailedTokenCheckState<TTokenType> _fallbackFailedTokenCheckState = new(fallback, fallbackStateCharacterCheck);
-    private readonly MixedCharacterCheckFailedEndOfTokenState<TTokenType> _endOfFallbackFailedTokenCheckState = new(fallbackStateEndOfTokenStateAccessor.EndOfTokenStateInstance);
+    private readonly FailedTokenCheckState<TTokenType> _fallbackFailedTokenCheckState;
+    private readonly MixedCharacterCheckFailedEndOfTokenState<TTokenType> _endOfFallbackFailedTokenCheckState;
 
-    private readonly MixedCharacterFailedTokenCheckState<TTokenType> _defaultFailedTokenCheckState = new(fallback, fallbackStateCharacterCheck);
-    private readonly MixedCharacterCheckFailedEndOfTokenState<TTokenType> _defaultEndOfFallbackFailedTokenCheckState = new(fallbackStateEndOfTokenStateAccessor.EndOfTokenStateInstance);
-    
-    public EndOfTokenState<TTokenType> EndOfTokenStateInstance => fallbackStateEndOfTokenStateAccessor.EndOfTokenStateInstance;
+    private readonly MixedCharacterFailedTokenCheckState<TTokenType> _defaultFailedTokenCheckState;
+    private readonly MixedCharacterCheckFailedEndOfTokenState<TTokenType> _defaultEndOfFallbackFailedTokenCheckState;
+    private readonly IEndOfTokenStateAccessor<TTokenType> _fallbackStateEndOfTokenStateAccessor;
+    private readonly IStateCharacterCheck _fallbackStateCharacterCheck;
+
+    public CheckForTokenState(ITokenTreeNode<TTokenType> node,
+        IState<TTokenType> fallbackState,
+        IEndOfTokenStateAccessor<TTokenType> fallbackStateEndOfTokenStateAccessor,
+        IStateCharacterCheck fallbackStateCharacterCheck) : base(node)
+    {
+        _fallbackStateEndOfTokenStateAccessor = fallbackStateEndOfTokenStateAccessor;
+        _fallbackStateCharacterCheck = fallbackStateCharacterCheck;
+        
+        _fallbackFailedTokenCheckState =
+            new FailedTokenCheckState<TTokenType>(fallbackState, fallbackStateCharacterCheck);
+        
+        _endOfFallbackFailedTokenCheckState =
+            new MixedCharacterCheckFailedEndOfTokenState<TTokenType>(fallbackStateEndOfTokenStateAccessor
+                .EndOfTokenStateInstance);
+        
+        _defaultFailedTokenCheckState =
+            new MixedCharacterFailedTokenCheckState<TTokenType>(fallbackState, fallbackStateCharacterCheck);
+        
+        _defaultEndOfFallbackFailedTokenCheckState =
+            new MixedCharacterCheckFailedEndOfTokenState<TTokenType>(fallbackStateEndOfTokenStateAccessor
+                .EndOfTokenStateInstance);
+
+        StateLookup = BuildStateLookup(node, fallbackState, fallbackStateEndOfTokenStateAccessor, fallbackStateCharacterCheck);
+    }
+
+    public EndOfTokenState<TTokenType> EndOfTokenStateInstance => _fallbackStateEndOfTokenStateAccessor.EndOfTokenStateInstance;
 
     protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
     {
@@ -26,7 +48,7 @@ internal class CheckForTokenState<TTokenType>(
         if (StateLookup.TryGetState(c, out nextState!))
             return true;
         
-        if (fallbackStateCharacterCheck.CharacterIsValidForState(c))
+        if (_fallbackStateCharacterCheck.CharacterIsValidForState(c))
         {
             nextState = _fallbackFailedTokenCheckState;
         }
@@ -42,7 +64,7 @@ internal class CheckForTokenState<TTokenType>(
     {
         Debug.Assert(!Node.IsEndOfToken);
         
-        if (fallbackStateCharacterCheck.CharacterIsValidForState(Node.Character))
+        if (_fallbackStateCharacterCheck.CharacterIsValidForState(Node.Character))
         {
             defaultState = _defaultFailedTokenCheckState;
         }
@@ -54,30 +76,24 @@ internal class CheckForTokenState<TTokenType>(
         return true;
     }
 
-    protected static CheckForTokenState<TTokenType> For(
-        ITokenTreeNode<TTokenType> node,
-        IState<TTokenType> fallbackState,
-        IEndOfTokenStateAccessor<TTokenType> fallbackStateEndOfTokenAccessor,
-        IStateCharacterCheck fallbackStateCharacterCheck)
+    private static IStateLookup<TTokenType> BuildStateLookup(ITokenTreeNode<TTokenType> node, IState<TTokenType> fallbackState,
+        IEndOfTokenStateAccessor<TTokenType> fallbackStateEndOfTokenStateAccessor, IStateCharacterCheck fallbackStateCharacterCheck)
     {
         var childStates = new StateLookupBuilder<TTokenType>();
         foreach (ITokenTreeNode<TTokenType> childNode in node)
         {
             if (childNode.IsEndOfToken)
             {
-                childStates.Add(childNode.Character, fallbackStateEndOfTokenAccessor.EndOfTokenStateInstance);
+                childStates.Add(childNode.Character, fallbackStateEndOfTokenStateAccessor.EndOfTokenStateInstance);
             }
             else
             {
                 childStates.Add(childNode.Character,
-                    For(childNode, fallbackState, fallbackStateEndOfTokenAccessor, fallbackStateCharacterCheck));
+                    new CheckForTokenState<TTokenType>(childNode, fallbackState, fallbackStateEndOfTokenStateAccessor,
+                        fallbackStateCharacterCheck));
             }
         }
 
-        return new CheckForTokenState<TTokenType>(node, fallbackState, fallbackStateEndOfTokenAccessor,
-            fallbackStateCharacterCheck)
-        {
-            StateLookup = childStates.Build()
-        };
+        return childStates.Build();
     }
 }

--- a/Tokensharp/StateMachine/CheckForTokenState.cs
+++ b/Tokensharp/StateMachine/CheckForTokenState.cs
@@ -41,39 +41,29 @@ internal class CheckForTokenState<TTokenType> : NodeStateBase<TTokenType>, IEndO
 
     public EndOfTokenState<TTokenType> EndOfTokenStateInstance => _fallbackStateEndOfTokenStateAccessor.EndOfTokenStateInstance;
 
-    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
+    protected override IState<TTokenType> GetNextState(in char c)
     {
         Debug.Assert(!Node.IsEndOfToken);
         
-        if (StateLookup.TryGetState(c, out nextState!))
-            return true;
+        if (StateLookup.TryGetState(c, out IState<TTokenType>? nextState))
+            return nextState;
         
         if (_fallbackStateCharacterCheck.CharacterIsValidForState(c))
         {
-            nextState = _fallbackFailedTokenCheckState;
-        }
-        else
-        {
-            nextState = _endOfFallbackFailedTokenCheckState;
+            return _fallbackFailedTokenCheckState;
         }
 
-        return true;
+        return _endOfFallbackFailedTokenCheckState;
     }
 
-    protected override bool TryGetDefaultState(out IState<TTokenType> defaultState)
+    protected override IState<TTokenType> GetDefaultState()
     {
         Debug.Assert(!Node.IsEndOfToken);
         
         if (_fallbackStateCharacterCheck.CharacterIsValidForState(Node.Character))
-        {
-            defaultState = _defaultFailedTokenCheckState;
-        }
-        else
-        {
-            defaultState = _defaultEndOfFallbackFailedTokenCheckState;
-        }
+            return _defaultFailedTokenCheckState;
 
-        return true;
+        return _defaultEndOfFallbackFailedTokenCheckState;
     }
 
     private static IStateLookup<TTokenType> BuildStateLookup(ITokenTreeNode<TTokenType> node, IState<TTokenType> fallbackState,

--- a/Tokensharp/StateMachine/EndOfSingleCharacterTokenState.cs
+++ b/Tokensharp/StateMachine/EndOfSingleCharacterTokenState.cs
@@ -5,7 +5,8 @@ namespace Tokensharp.StateMachine;
 internal class EndOfSingleCharacterTokenState<TTokenType>(TTokenType tokenType) 
     : EndOfTokenState<TTokenType>(tokenType) where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    public override bool FinalizeToken(ref StateMachineContext context, out int length, [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
+    public override bool FinalizeToken(ref StateMachineContext context, out int length,
+        [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
     {
         length = 1;
         tokenType = TokenType;

--- a/Tokensharp/StateMachine/EndOfTokenState.cs
+++ b/Tokensharp/StateMachine/EndOfTokenState.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Tokensharp.StateMachine;
 
 internal class EndOfTokenState<TTokenType>(TTokenType tokenType)
@@ -15,23 +17,19 @@ internal class EndOfTokenState<TTokenType>(TTokenType tokenType)
         // NoOp
     }
 
-    public override bool FinalizeToken(ref StateMachineContext context, out int length, out TokenType<TTokenType> tokenType)
+    public override bool FinalizeToken(ref StateMachineContext context, out int length,
+        [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
     {
         length = context.FallbackLexemeLength > 0 ? context.FallbackLexemeLength : context.PotentialLexemeLength;
         tokenType = TokenType;
         return true;
     }
 
-    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
-    {
-        nextState = this;
-        return false;
-    }
+    protected override IState<TTokenType> GetNextState(in char c) => this;
 
-    protected override bool TryGetDefaultState(out IState<TTokenType> defaultState)
+    protected override IState<TTokenType> GetDefaultState()
     {
-        defaultState = this;
-        return false;
+        return this;
     }
 
     public bool CharacterIsValidForState(in char c)

--- a/Tokensharp/StateMachine/IState.cs
+++ b/Tokensharp/StateMachine/IState.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Tokensharp.StateMachine;
 
 internal interface IStateCharacterCheck
@@ -9,7 +11,8 @@ internal interface IState<TTokenType> : ITransitionHandler<TTokenType>
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
     bool IsEndOfToken { get; }
+
     void UpdateCounts(ref StateMachineContext context);
 
-    bool FinalizeToken(ref StateMachineContext context, out int lexemeLength, out TokenType<TTokenType> tokenType);
+    bool FinalizeToken(ref StateMachineContext context, out int lexemeLength, [NotNullWhen(true)] out TokenType<TTokenType>? tokenType);
 }

--- a/Tokensharp/StateMachine/ITransitionHandler.cs
+++ b/Tokensharp/StateMachine/ITransitionHandler.cs
@@ -3,6 +3,6 @@ namespace Tokensharp.StateMachine;
 internal interface ITransitionHandler<TTokenType> 
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    bool TryTransition(in char c, ref StateMachineContext context, out IState<TTokenType> nextState);
+    void Transition(in char c, ref StateMachineContext context, out IState<TTokenType> nextState);
     bool TryDefaultTransition(ref StateMachineContext context, out IState<TTokenType> defaultState);
 }

--- a/Tokensharp/StateMachine/MixedCharacterFailedTokenCheckState.cs
+++ b/Tokensharp/StateMachine/MixedCharacterFailedTokenCheckState.cs
@@ -5,16 +5,14 @@ internal class MixedCharacterFailedTokenCheckState<TTokenType>(IState<TTokenType
 {
     public override bool IsEndOfToken => false;
 
-    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
+    protected override IState<TTokenType> GetNextState(in char c)
     {
-        nextState = fallbackState;
-        return true;
+        return fallbackState;
     }
 
-    protected override bool TryGetDefaultState(out IState<TTokenType> defaultState)
+    protected override IState<TTokenType> GetDefaultState()
     {
-        defaultState = fallbackState;
-        return true;
+        return fallbackState;
     }
 
     public override void UpdateCounts(ref StateMachineContext context)

--- a/Tokensharp/StateMachine/PotentialTokenState.cs
+++ b/Tokensharp/StateMachine/PotentialTokenState.cs
@@ -16,28 +16,25 @@ internal class PotentialTokenState<TTokenType>(
 
     public EndOfTokenState<TTokenType> EndOfTokenStateInstance => _endOfTokenStateInstance;
 
-    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
+    protected override IState<TTokenType> GetNextState(in char c)
     {
-        if (StateLookup.TryGetState(c, out nextState!))
-            return true;
+        if (StateLookup.TryGetState(c, out IState<TTokenType>? nextState))
+            return nextState;
 
         if (Node.IsEndOfToken || !fallbackStateCharacterCheck.CharacterIsValidForState(c))
         {
-            nextState = _endOfTokenStateInstance;
-            return true;
+            return _endOfTokenStateInstance;
         }
 
-        if (rootStates.TryGetState(c, out nextState!))
-            return true;
+        if (rootStates.TryGetState(c, out nextState))
+            return nextState;
         
-        nextState = _endOfTokenStateInstance;
-        return true;
+        return _endOfTokenStateInstance;
     }
 
-    protected override bool TryGetDefaultState(out IState<TTokenType> defaultState)
+    protected override IState<TTokenType> GetDefaultState()
     {
-        defaultState = _endOfTokenStateInstance;
-        return true;
+        return _endOfTokenStateInstance;
     }
 
     public override void UpdateCounts(ref StateMachineContext context)

--- a/Tokensharp/StateMachine/PotentialTokenState.cs
+++ b/Tokensharp/StateMachine/PotentialTokenState.cs
@@ -60,7 +60,8 @@ internal class PotentialTokenState<TTokenType>(
                 rootStates.Add(startNode.Character, fallbackEndOfTokenStateAccessor.EndOfTokenStateInstance);
             else
                 rootStates.Add(startNode.Character,
-                    StartOfCheckForTokenState<TTokenType>.For(startNode, fallbackState, fallbackEndOfTokenStateAccessor, fallbackStateCharacterCheck));
+                    new StartOfCheckForTokenState<TTokenType>(startNode, fallbackState, fallbackEndOfTokenStateAccessor,
+                        fallbackStateCharacterCheck));
         }
 
         if (node.IsEndOfToken)

--- a/Tokensharp/StateMachine/StartOfCheckForTokenState.cs
+++ b/Tokensharp/StateMachine/StartOfCheckForTokenState.cs
@@ -7,38 +7,12 @@ internal class StartOfCheckForTokenState<TTokenType>(
     IState<TTokenType> fallback,
     IEndOfTokenStateAccessor<TTokenType> fallbackStateEndOfTokenStateAccessor,
     IStateCharacterCheck fallbackStateCharacterCheck)
-    : CheckForTokenState<TTokenType>(node, fallback, fallbackStateEndOfTokenStateAccessor, fallbackStateCharacterCheck) 
+    : CheckForTokenState<TTokenType>(node, fallback, fallbackStateEndOfTokenStateAccessor, fallbackStateCharacterCheck)
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
     public override void UpdateCounts(ref StateMachineContext context)
     {
         context.FallbackLexemeLength = context.PotentialLexemeLength;
         context.PotentialLexemeLength++;
-    }
-
-    public new static StartOfCheckForTokenState<TTokenType> For(
-        ITokenTreeNode<TTokenType> node,
-        IState<TTokenType> fallbackState,
-        IEndOfTokenStateAccessor<TTokenType> fallbackStateEndOfTokenStateAccessor,
-        IStateCharacterCheck fallbackStateCharacterCheck)
-    {
-        var childStates = new StateLookupBuilder<TTokenType>();
-        foreach (ITokenTreeNode<TTokenType> childNode in node)
-        {
-            if (childNode.IsEndOfToken)
-            {
-                childStates.Add(childNode.Character, fallbackStateEndOfTokenStateAccessor.EndOfTokenStateInstance);
-            }
-            else
-            {
-                childStates.Add(childNode.Character, CheckForTokenState<TTokenType>.For(childNode, fallbackState, fallbackStateEndOfTokenStateAccessor, fallbackStateCharacterCheck));
-            }
-        }
-
-        return new StartOfCheckForTokenState<TTokenType>(node, fallbackState, fallbackStateEndOfTokenStateAccessor,
-            fallbackStateCharacterCheck)
-        {
-            StateLookup = childStates.Build()
-        };
     }
 }

--- a/Tokensharp/StateMachine/StartState.cs
+++ b/Tokensharp/StateMachine/StartState.cs
@@ -7,6 +7,8 @@ internal class StartState<TTokenType> : NodeStateBase<TTokenType>
 {
     private readonly ITextWhiteSpaceNumberLookup<TTokenType> _textWhiteSpaceNumberLookup;
 
+    public override bool IsEndOfToken => true;
+
     public StartState(ITokenTreeNode<TTokenType> tokenTreeNode, bool numbersAreText) : base(tokenTreeNode.RootNode)
     {
         _textWhiteSpaceNumberLookup = numbersAreText
@@ -32,18 +34,15 @@ internal class StartState<TTokenType> : NodeStateBase<TTokenType>
         StateLookup = startStates.Build();
     }
 
-    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
+    protected override IState<TTokenType> GetNextState(in char c)
     {
-        if (StateLookup.TryGetState(c, out nextState!))
-            return true;
-
-        nextState = _textWhiteSpaceNumberLookup.GetState(in c);
-        return true;
+        return StateLookup.TryGetState(c, out IState<TTokenType>? nextState)
+            ? nextState
+            : _textWhiteSpaceNumberLookup.GetState(in c);
     }
 
-    protected override bool TryGetDefaultState(out IState<TTokenType> defaultState)
+    protected override IState<TTokenType> GetDefaultState()
     {
-        defaultState = this;
-        return false;
+        return this;
     }
 }

--- a/Tokensharp/StateMachine/State.cs
+++ b/Tokensharp/StateMachine/State.cs
@@ -6,30 +6,27 @@ internal abstract class State<TTokenType> : IState<TTokenType> where TTokenType 
 {
     public abstract bool IsEndOfToken { get; }
 
-    public virtual bool TryTransition(in char c, ref StateMachineContext context, out IState<TTokenType> nextState)
+    public void Transition(in char c, ref StateMachineContext context, out IState<TTokenType> nextState)
     {
-        if (!TryGetNextState(in c, out nextState) &&
-            !TryGetDefaultState(out nextState))
-            return false;
-        
+        nextState = GetNextState(in c);
         nextState.UpdateCounts(ref context);
-        return !nextState.IsEndOfToken;
     }
 
-    protected abstract bool TryGetNextState(in char c, out IState<TTokenType> nextState);
+    protected abstract IState<TTokenType> GetNextState(in char c);
 
-    public virtual bool TryDefaultTransition(ref StateMachineContext context, out IState<TTokenType> defaultState)
+    public bool TryDefaultTransition(ref StateMachineContext context, out IState<TTokenType> defaultState)
     {
-        if (!TryGetDefaultState(out defaultState))
-            return false;
-
+        defaultState = GetDefaultState();
+        
         defaultState.UpdateCounts(ref context);
-        return true;
+
+        return !defaultState.IsEndOfToken;
     }
 
-    protected abstract bool TryGetDefaultState(out IState<TTokenType> defaultState);
+    protected abstract IState<TTokenType> GetDefaultState();
     
-    public virtual bool FinalizeToken(ref StateMachineContext context, out int lexemeLength, [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
+    public virtual bool FinalizeToken(ref StateMachineContext context, out int lexemeLength,
+        [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
     {
         lexemeLength = 0;
         tokenType = null;

--- a/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
+++ b/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
@@ -48,7 +48,7 @@ internal abstract class TextWhiteSpaceNumberBase<TTokenType> : NodeStateBase<TTo
             else
             {
                 textWhiteSpaceNumberStates.Add(startNode.Character,
-                    StartOfCheckForTokenState<TTokenType>.For(startNode, this, this, this));
+                    new StartOfCheckForTokenState<TTokenType>(startNode, this, this, this));
             }
         }
 

--- a/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
+++ b/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
@@ -15,20 +15,20 @@ internal abstract class TextWhiteSpaceNumberBase<TTokenType> : NodeStateBase<TTo
 
     public EndOfTokenState<TTokenType> EndOfTokenStateInstance => _endOfTokenStateInstance;
 
-    protected override bool TryGetNextState(in char c, out IState<TTokenType> nextState)
+    protected override IState<TTokenType> GetNextState(in char c)
     {
-        if (StateLookup.TryGetState(in c, out nextState!))
-            return true;
+        if (StateLookup.TryGetState(in c, out IState<TTokenType>? nextState))
+            return nextState;
 
-        nextState = CharacterIsValidForState(c) ? this : _endOfTokenStateInstance;
-
-        return true;
+        if (CharacterIsValidForState(c))
+            return this;
+        
+        return _endOfTokenStateInstance;
     }
 
-    protected override bool TryGetDefaultState(out IState<TTokenType> defaultState)
+    protected override IState<TTokenType> GetDefaultState()
     {
-        defaultState = _endOfTokenStateInstance;
-        return true;
+        return _endOfTokenStateInstance;
     }
 
     private IStateLookup<TTokenType> BuildStateLookup(ITokenTreeNode<TTokenType> tokenTreeNode)

--- a/Tokensharp/TokenParser.cs
+++ b/Tokensharp/TokenParser.cs
@@ -34,16 +34,9 @@ public readonly ref struct TokenParser<TTokenType>(TokenConfiguration<TTokenType
 
         foreach (char c in buffer)
         {
-            if (currentState.TryTransition(c, ref context, out currentState))
-                continue;
-            
-            Debug.Assert(currentState is not null, $"State transition failed for character: {c}");
-            
-            bool tokenFinalized = currentState.FinalizeToken(ref context, out length, out tokenType);
-            
-            Debug.Assert(tokenFinalized, $"Finalize token failed: '{c}', Current state: {currentState}");
-
-            return tokenFinalized;
+            currentState.Transition(c, ref context, out currentState);
+            if (currentState.IsEndOfToken)
+                return currentState.FinalizeToken(ref context, out length, out tokenType);
         }
         
         while (!moreDataAvailable && currentState.TryDefaultTransition(ref context, out currentState)) ;


### PR DESCRIPTION
### Description

This pull request refactors the state machine logic and simplifies state initialization:

- Replaced `Try` pattern methods (`TryGetNextState`, `TryGetDefaultState`) with direct `GetNextState` and `GetDefaultState` methods that return `IState<TTokenType>` directly.
- Modified `TryTransition` to `Transition` with a void return type.
- Introduced `[NotNullWhen(true)]` attribute to `FinalizeToken` out parameters for improved nullability checks.
- Updated `TokenParser` logic to rely on explicit `IsEndOfToken` checks after transitions.
- Removed static factory methods (`For`) in `CheckForTokenState` and `StartOfCheckForTokenState` in favor of constructors for cleaner and more explicit initialization.
- Adjusted dependent classes (`TextWhiteSpaceNumberBase`, `PotentialTokenState`) to use the new constructors for state instantiation.