### PR TITLE
Refactor state transition logic to return IState directly

### DIFF
--- a/Tokensharp/StateMachine/ITransitionHandler.cs
+++ b/Tokensharp/StateMachine/ITransitionHandler.cs
@@ -3,6 +3,6 @@ namespace Tokensharp.StateMachine;
 internal interface ITransitionHandler<TTokenType> 
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    void Transition(in char c, ref StateMachineContext context, out IState<TTokenType> nextState);
-    bool TryDefaultTransition(ref StateMachineContext context, out IState<TTokenType> defaultState);
+    IState<TTokenType> Transition(in char c, ref StateMachineContext context);
+    IState<TTokenType> PerformDefaultTransition(ref StateMachineContext context);
 }

--- a/Tokensharp/StateMachine/State.cs
+++ b/Tokensharp/StateMachine/State.cs
@@ -6,21 +6,20 @@ internal abstract class State<TTokenType> : IState<TTokenType> where TTokenType 
 {
     public abstract bool IsEndOfToken { get; }
 
-    public void Transition(in char c, ref StateMachineContext context, out IState<TTokenType> nextState)
+    public IState<TTokenType> Transition(in char c, ref StateMachineContext context)
     {
-        nextState = GetNextState(in c);
+        IState<TTokenType> nextState = GetNextState(in c);
         nextState.UpdateCounts(ref context);
+        return nextState;
     }
 
     protected abstract IState<TTokenType> GetNextState(in char c);
 
-    public bool TryDefaultTransition(ref StateMachineContext context, out IState<TTokenType> defaultState)
+    public IState<TTokenType> PerformDefaultTransition(ref StateMachineContext context)
     {
-        defaultState = GetDefaultState();
-        
+        IState<TTokenType> defaultState = GetDefaultState();
         defaultState.UpdateCounts(ref context);
-
-        return !defaultState.IsEndOfToken;
+        return defaultState;
     }
 
     protected abstract IState<TTokenType> GetDefaultState();

--- a/Tokensharp/TokenParser.cs
+++ b/Tokensharp/TokenParser.cs
@@ -34,12 +34,16 @@ public readonly ref struct TokenParser<TTokenType>(TokenConfiguration<TTokenType
 
         foreach (char c in buffer)
         {
-            currentState.Transition(c, ref context, out currentState);
+            currentState = currentState.Transition(c, ref context);
             if (currentState.IsEndOfToken)
                 return currentState.FinalizeToken(ref context, out length, out tokenType);
         }
-        
-        while (!moreDataAvailable && currentState.TryDefaultTransition(ref context, out currentState)) ;
+
+        if (!moreDataAvailable)
+        {
+            while (!currentState.IsEndOfToken)
+                currentState = currentState.PerformDefaultTransition(ref context);
+        }
             
         Debug.Assert(currentState is not null, "Default state transition resulted in null state");
             


### PR DESCRIPTION
Updated state transition methods to directly return IState instead of using out parameters. Renamed and adjusted related methods to align with the new API and improved readability.