### PR TITLE
Simplify and optimize TokenReader.Read logic

### DIFF
--- a/Tokensharp/ReadBuffer.cs
+++ b/Tokensharp/ReadBuffer.cs
@@ -97,6 +97,6 @@ internal struct ReadBuffer(int initialBufferSize) : IDisposable
         char[] toReturn = _buffer;
         _buffer = null!;
         
-        ArrayPool<char>.Shared.Return(toReturn, true);
+        ArrayPool<char>.Shared.Return(toReturn);
     }
 }

--- a/Tokensharp/TokenReader.cs
+++ b/Tokensharp/TokenReader.cs
@@ -35,25 +35,20 @@ public ref struct TokenReader<TTokenType>(
 
     public bool Read([NotNullWhen(true)] out TokenType<TTokenType>? tokenType, out int index, out int length)
     {
-        tokenType = null;
         index = Consumed;
-        length = 0;
         
         TokenParser<TTokenType> tokenParser = _tokenParser;
 
-        while (tokenParser.TryParseToken(_buffer[Consumed..], moreDataAvailable, out tokenType, out int potentialLength))
+        while (tokenParser.TryParseToken(_buffer[index..], moreDataAvailable, out tokenType, out length))
         {
-            if (!options.IgnoreWhiteSpace || tokenType != TokenType<TTokenType>.WhiteSpace)
-            {
-                length = potentialLength;
-                break;
-            }
+            Consumed += length;
 
-            Consumed += potentialLength;
+            if (!options.IgnoreWhiteSpace || tokenType != TokenType<TTokenType>.WhiteSpace)
+                return true;
+
             index = Consumed;
         }
-        
-        Consumed += length;
-        return tokenType is not null;
+
+        return false;
     }
 }


### PR DESCRIPTION
Refactored the `TokenReader.Read` method to simplify the logic by immediately returning when a token is found, improving readability and efficiency. Additionally, optimized the `ReadBuffer.Dispose` method by skipping the clearing of the array before returning it to the pool.