### PR TITLE
Refactor state management and bump version to 4.5.3

### DIFF
--- a/Tokensharp/StateMachine/CheckForTokenState.cs
+++ b/Tokensharp/StateMachine/CheckForTokenState.cs
@@ -56,14 +56,17 @@ internal class CheckForTokenState<TTokenType> : NodeStateBase<TTokenType>, IEndO
         return _endOfFallbackFailedTokenCheckState;
     }
 
-    protected override IState<TTokenType> GetDefaultState()
+    protected override IState<TTokenType> DefaultState
     {
-        Debug.Assert(!Node.IsEndOfToken);
-        
-        if (_fallbackStateCharacterCheck.CharacterIsValidForState(Node.Character))
-            return _defaultFailedTokenCheckState;
+        get
+        {
+            Debug.Assert(!Node.IsEndOfToken);
 
-        return _defaultEndOfFallbackFailedTokenCheckState;
+            if (_fallbackStateCharacterCheck.CharacterIsValidForState(Node.Character))
+                return _defaultFailedTokenCheckState;
+
+            return _defaultEndOfFallbackFailedTokenCheckState;
+        }
     }
 
     private static IStateLookup<TTokenType> BuildStateLookup(ITokenTreeNode<TTokenType> node, IState<TTokenType> fallbackState,

--- a/Tokensharp/StateMachine/EndOfTokenState.cs
+++ b/Tokensharp/StateMachine/EndOfTokenState.cs
@@ -27,10 +27,7 @@ internal class EndOfTokenState<TTokenType>(TTokenType tokenType)
 
     protected override IState<TTokenType> GetNextState(in char c) => this;
 
-    protected override IState<TTokenType> GetDefaultState()
-    {
-        return this;
-    }
+    protected override IState<TTokenType> DefaultState => this;
 
     public bool CharacterIsValidForState(in char c)
     {

--- a/Tokensharp/StateMachine/MixedCharacterFailedTokenCheckState.cs
+++ b/Tokensharp/StateMachine/MixedCharacterFailedTokenCheckState.cs
@@ -10,10 +10,7 @@ internal class MixedCharacterFailedTokenCheckState<TTokenType>(IState<TTokenType
         return fallbackState;
     }
 
-    protected override IState<TTokenType> GetDefaultState()
-    {
-        return fallbackState;
-    }
+    protected override IState<TTokenType> DefaultState => fallbackState;
 
     public override void UpdateCounts(ref StateMachineContext context)
     {

--- a/Tokensharp/StateMachine/PotentialTokenState.cs
+++ b/Tokensharp/StateMachine/PotentialTokenState.cs
@@ -60,15 +60,10 @@ internal class PotentialTokenState<TTokenType> : NodeStateBase<TTokenType>, IEnd
 
     protected override IState<TTokenType> GetNextState(in char c)
     {
-        if (StateLookup.TryGetState(c, out IState<TTokenType>? nextState))
+        if (StateLookup.TryGetState(c, out IState<TTokenType>? nextState) || 
+            !Node.IsEndOfToken && _fallbackStateCharacterCheck.CharacterIsValidForState(c) && _rootStates.TryGetState(c, out nextState))
             return nextState;
 
-        if (Node.IsEndOfToken || !_fallbackStateCharacterCheck.CharacterIsValidForState(c))
-            return _endOfTokenStateInstance;
-
-        if (_rootStates.TryGetState(c, out nextState))
-            return nextState;
-        
         return _endOfTokenStateInstance;
     }
 

--- a/Tokensharp/StateMachine/PotentialTokenState.cs
+++ b/Tokensharp/StateMachine/PotentialTokenState.cs
@@ -22,9 +22,7 @@ internal class PotentialTokenState<TTokenType>(
             return nextState;
 
         if (Node.IsEndOfToken || !fallbackStateCharacterCheck.CharacterIsValidForState(c))
-        {
             return _endOfTokenStateInstance;
-        }
 
         if (rootStates.TryGetState(c, out nextState))
             return nextState;
@@ -32,10 +30,7 @@ internal class PotentialTokenState<TTokenType>(
         return _endOfTokenStateInstance;
     }
 
-    protected override IState<TTokenType> GetDefaultState()
-    {
-        return _endOfTokenStateInstance;
-    }
+    protected override IState<TTokenType> DefaultState => _endOfTokenStateInstance;
 
     public override void UpdateCounts(ref StateMachineContext context)
     {

--- a/Tokensharp/StateMachine/PotentialTokenState.cs
+++ b/Tokensharp/StateMachine/PotentialTokenState.cs
@@ -2,17 +2,59 @@ using Tokensharp.TokenTree;
 
 namespace Tokensharp.StateMachine;
 
-internal class PotentialTokenState<TTokenType>(
-    ITokenTreeNode<TTokenType> node,
-    IEndOfTokenStateAccessor<TTokenType> fallbackEndOfTokenStateAccessor,
-    IStateCharacterCheck fallbackStateCharacterCheck,
-    IStateLookup<TTokenType> rootStates)
-    : NodeStateBase<TTokenType>(node), IEndOfTokenStateAccessor<TTokenType>
+internal class PotentialTokenState<TTokenType> : NodeStateBase<TTokenType>, IEndOfTokenStateAccessor<TTokenType>
     where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    private readonly EndOfTokenState<TTokenType> _endOfTokenStateInstance = node.IsEndOfToken
-        ? new EndOfTokenState<TTokenType>(node.TokenType)
-        : fallbackEndOfTokenStateAccessor.EndOfTokenStateInstance;
+    private readonly EndOfTokenState<TTokenType> _endOfTokenStateInstance;
+
+    private readonly IStateCharacterCheck _fallbackStateCharacterCheck;
+    private readonly IStateLookup<TTokenType> _rootStates;
+
+    public PotentialTokenState(ITokenTreeNode<TTokenType> node,
+        IState<TTokenType> fallbackState,
+        IEndOfTokenStateAccessor<TTokenType> fallbackEndOfTokenStateAccessor,
+        IStateCharacterCheck fallbackStateCharacterCheck) : base(node)
+    {
+        _fallbackStateCharacterCheck = fallbackStateCharacterCheck;
+        _endOfTokenStateInstance = node.IsEndOfToken
+            ? new EndOfTokenState<TTokenType>(node.TokenType)
+            : fallbackEndOfTokenStateAccessor.EndOfTokenStateInstance;
+        
+        var rootStatesBuilder = new StateLookupBuilder<TTokenType>();
+
+        foreach (ITokenTreeNode<TTokenType> startNode in node.RootNode)
+        {
+            if (startNode.IsEndOfToken)
+                rootStatesBuilder.Add(startNode.Character, fallbackEndOfTokenStateAccessor.EndOfTokenStateInstance);
+            else
+                rootStatesBuilder.Add(startNode.Character,
+                    new StartOfCheckForTokenState<TTokenType>(startNode, fallbackState, fallbackEndOfTokenStateAccessor,
+                        fallbackStateCharacterCheck));
+        }
+        
+        _rootStates = rootStatesBuilder.Build();
+
+        // If this is an end of token node then we should fallback to this token if we don't find a longer one
+        if (node.IsEndOfToken)
+        {
+            var endOfTokenStateAccessor = new EndOfTokenState<TTokenType>(node.TokenType);
+            fallbackState = endOfTokenStateAccessor;
+            fallbackEndOfTokenStateAccessor = endOfTokenStateAccessor;
+            fallbackStateCharacterCheck = endOfTokenStateAccessor;
+        }
+
+        var childStatesBuilder = new StateLookupBuilder<TTokenType>();
+        foreach (ITokenTreeNode<TTokenType> childNode in node)
+        {
+            if (childNode.HasChildren)
+                childStatesBuilder.Add(childNode.Character,
+                    new PotentialTokenState<TTokenType>(childNode, fallbackState, fallbackEndOfTokenStateAccessor, fallbackStateCharacterCheck));
+            else
+                childStatesBuilder.Add(childNode.Character, new EndOfPotentialTokenState<TTokenType>(childNode.TokenType));
+        }
+        
+        StateLookup = childStatesBuilder.Build();
+    }
 
     public EndOfTokenState<TTokenType> EndOfTokenStateInstance => _endOfTokenStateInstance;
 
@@ -21,10 +63,10 @@ internal class PotentialTokenState<TTokenType>(
         if (StateLookup.TryGetState(c, out IState<TTokenType>? nextState))
             return nextState;
 
-        if (Node.IsEndOfToken || !fallbackStateCharacterCheck.CharacterIsValidForState(c))
+        if (Node.IsEndOfToken || !_fallbackStateCharacterCheck.CharacterIsValidForState(c))
             return _endOfTokenStateInstance;
 
-        if (rootStates.TryGetState(c, out nextState))
+        if (_rootStates.TryGetState(c, out nextState))
             return nextState;
         
         return _endOfTokenStateInstance;
@@ -37,47 +79,5 @@ internal class PotentialTokenState<TTokenType>(
         context.PotentialLexemeLength++;
         if (Node.IsEndOfToken)
             context.FallbackLexemeLength = context.PotentialLexemeLength;
-    }
-
-    public static PotentialTokenState<TTokenType> For(ITokenTreeNode<TTokenType> node,
-        IState<TTokenType> fallbackState,
-        IEndOfTokenStateAccessor<TTokenType> fallbackEndOfTokenStateAccessor,
-        IStateCharacterCheck fallbackStateCharacterCheck)
-    {
-        var rootStates = new StateLookupBuilder<TTokenType>();
-
-        foreach (ITokenTreeNode<TTokenType> startNode in node.RootNode)
-        {
-            if (startNode.IsEndOfToken)
-                rootStates.Add(startNode.Character, fallbackEndOfTokenStateAccessor.EndOfTokenStateInstance);
-            else
-                rootStates.Add(startNode.Character,
-                    new StartOfCheckForTokenState<TTokenType>(startNode, fallbackState, fallbackEndOfTokenStateAccessor,
-                        fallbackStateCharacterCheck));
-        }
-
-        if (node.IsEndOfToken)
-        {
-            var endOfTokenStateAccessor = new EndOfTokenState<TTokenType>(node.TokenType);
-            fallbackState = endOfTokenStateAccessor;
-            fallbackEndOfTokenStateAccessor = endOfTokenStateAccessor;
-            fallbackStateCharacterCheck = endOfTokenStateAccessor;
-        }
-
-        var childStates = new StateLookupBuilder<TTokenType>();
-        foreach (ITokenTreeNode<TTokenType> childNode in node)
-        {
-            if (childNode.HasChildren)
-                childStates.Add(childNode.Character,
-                    For(childNode, fallbackState, fallbackEndOfTokenStateAccessor, fallbackStateCharacterCheck));
-            else
-                childStates.Add(childNode.Character, new EndOfPotentialTokenState<TTokenType>(childNode.TokenType));
-        }
-
-        return new PotentialTokenState<TTokenType>(node, fallbackEndOfTokenStateAccessor, fallbackStateCharacterCheck,
-            rootStates.Build())
-        {
-            StateLookup = childStates.Build()
-        };
     }
 }

--- a/Tokensharp/StateMachine/StartState.cs
+++ b/Tokensharp/StateMachine/StartState.cs
@@ -23,7 +23,7 @@ internal class StartState<TTokenType> : NodeStateBase<TTokenType>
             
             if (startNode.HasChildren)
             {
-                startStates.Add(startNode.Character, PotentialTokenState<TTokenType>.For(startNode, fallback, fallback, fallback));
+                startStates.Add(startNode.Character, new PotentialTokenState<TTokenType>(startNode, fallback, fallback, fallback));
             }
             else
             {

--- a/Tokensharp/StateMachine/StartState.cs
+++ b/Tokensharp/StateMachine/StartState.cs
@@ -41,8 +41,5 @@ internal class StartState<TTokenType> : NodeStateBase<TTokenType>
             : _textWhiteSpaceNumberLookup.GetState(in c);
     }
 
-    protected override IState<TTokenType> GetDefaultState()
-    {
-        return this;
-    }
+    protected override IState<TTokenType> DefaultState => this;
 }

--- a/Tokensharp/StateMachine/State.cs
+++ b/Tokensharp/StateMachine/State.cs
@@ -17,13 +17,12 @@ internal abstract class State<TTokenType> : IState<TTokenType> where TTokenType 
 
     public IState<TTokenType> PerformDefaultTransition(ref StateMachineContext context)
     {
-        IState<TTokenType> defaultState = GetDefaultState();
-        defaultState.UpdateCounts(ref context);
-        return defaultState;
+        DefaultState.UpdateCounts(ref context);
+        return DefaultState;
     }
 
-    protected abstract IState<TTokenType> GetDefaultState();
-    
+    protected abstract IState<TTokenType> DefaultState { get; }
+
     public virtual bool FinalizeToken(ref StateMachineContext context, out int lexemeLength,
         [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
     {

--- a/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
+++ b/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
@@ -26,10 +26,7 @@ internal abstract class TextWhiteSpaceNumberBase<TTokenType> : NodeStateBase<TTo
         return _endOfTokenStateInstance;
     }
 
-    protected override IState<TTokenType> GetDefaultState()
-    {
-        return _endOfTokenStateInstance;
-    }
+    protected override IState<TTokenType> DefaultState => _endOfTokenStateInstance;
 
     private IStateLookup<TTokenType> BuildStateLookup(ITokenTreeNode<TTokenType> tokenTreeNode)
     {

--- a/Tokensharp/Tokensharp.csproj
+++ b/Tokensharp/Tokensharp.csproj
@@ -9,7 +9,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>4.5.2</Version>
+        <Version>4.5.3</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 

--- a/Tokensharp/Tokensharp.csproj
+++ b/Tokensharp/Tokensharp.csproj
@@ -13,11 +13,6 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 
-    <PropertyGroup>
-        <!-- Use 2.0.0 as default package version if not specified -->
-        <SwiftStateVersion Condition="'$(SwiftStateVersion)' == ''">3.0.0-beta.2</SwiftStateVersion>
-    </PropertyGroup>
-
     <ItemGroup>
         <None Include="$(SolutionDir)\README.md" Pack="true" PackagePath="" />
     </ItemGroup>


### PR DESCRIPTION
### Summary

This pull request refactors various state management functionalities and increments the project version to 4.5.3. Specific changes include:

- Removed the unused `SwiftStateVersion` property from the project file.
- Simplified the `GetNextState` logic in the `PotentialTokenState` class by combining conditional checks.
- Replaced the static factory method with a standard constructor in `PotentialTokenState` and adjusted internal logic accordingly.
- Refactored `GetDefaultState` into a `DefaultState` property in the `State` base class and updated all derived classes to use the property.
- Bumped the version to 4.5.3 to reflect the latest updates.