### PR TITLE
Refactor TokenParser and Benchmark for clarity

### DIFF
--- a/Tokensharp/StateMachine/CheckForTokenState.cs
+++ b/Tokensharp/StateMachine/CheckForTokenState.cs
@@ -48,7 +48,7 @@ internal class CheckForTokenState<TTokenType> : NodeStateBase<TTokenType>, IEndO
         if (StateLookup.TryGetState(c, out IState<TTokenType>? nextState))
             return nextState;
         
-        if (_fallbackStateCharacterCheck.CharacterIsValidForState(c))
+        if (_fallbackStateCharacterCheck.CharacterIsValidForState(in c))
         {
             return _fallbackFailedTokenCheckState;
         }

--- a/Tokensharp/StateMachine/EndOfSingleCharacterTokenState.cs
+++ b/Tokensharp/StateMachine/EndOfSingleCharacterTokenState.cs
@@ -5,8 +5,8 @@ namespace Tokensharp.StateMachine;
 internal class EndOfSingleCharacterTokenState<TTokenType>(TTokenType tokenType) 
     : EndOfTokenState<TTokenType>(tokenType) where TTokenType : TokenType<TTokenType>, ITokenType<TTokenType>
 {
-    public override bool FinalizeToken(ref StateMachineContext context, out int length,
-        [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
+    public override bool FinalizeToken(ref StateMachineContext context, [NotNullWhen(true)] ref TokenType<TTokenType>? tokenType,
+        ref int length)
     {
         length = 1;
         tokenType = TokenType;

--- a/Tokensharp/StateMachine/EndOfTokenState.cs
+++ b/Tokensharp/StateMachine/EndOfTokenState.cs
@@ -17,8 +17,8 @@ internal class EndOfTokenState<TTokenType>(TTokenType tokenType)
         // NoOp
     }
 
-    public override bool FinalizeToken(ref StateMachineContext context, out int length,
-        [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
+    public override bool FinalizeToken(ref StateMachineContext context, [NotNullWhen(true)] ref TokenType<TTokenType>? tokenType,
+        ref int length)
     {
         length = context.FallbackLexemeLength > 0 ? context.FallbackLexemeLength : context.PotentialLexemeLength;
         tokenType = TokenType;

--- a/Tokensharp/StateMachine/IState.cs
+++ b/Tokensharp/StateMachine/IState.cs
@@ -14,5 +14,6 @@ internal interface IState<TTokenType> : ITransitionHandler<TTokenType>
 
     void UpdateCounts(ref StateMachineContext context);
 
-    bool FinalizeToken(ref StateMachineContext context, out int lexemeLength, [NotNullWhen(true)] out TokenType<TTokenType>? tokenType);
+    bool FinalizeToken(ref StateMachineContext context, [NotNullWhen(true)] ref TokenType<TTokenType>? tokenType,
+        ref int lexemeLength);
 }

--- a/Tokensharp/StateMachine/MixedCharacterFailedTokenCheckState.cs
+++ b/Tokensharp/StateMachine/MixedCharacterFailedTokenCheckState.cs
@@ -17,5 +17,5 @@ internal class MixedCharacterFailedTokenCheckState<TTokenType>(IState<TTokenType
         context.FallbackLexemeLength = context.PotentialLexemeLength;
     }
 
-    public bool CharacterIsValidForState(in char c) => fallbackStateCharacterCheck.CharacterIsValidForState(c);
+    public bool CharacterIsValidForState(in char c) => fallbackStateCharacterCheck.CharacterIsValidForState(in c);
 }

--- a/Tokensharp/StateMachine/PotentialTokenState.cs
+++ b/Tokensharp/StateMachine/PotentialTokenState.cs
@@ -60,8 +60,9 @@ internal class PotentialTokenState<TTokenType> : NodeStateBase<TTokenType>, IEnd
 
     protected override IState<TTokenType> GetNextState(in char c)
     {
-        if (StateLookup.TryGetState(c, out IState<TTokenType>? nextState) || 
-            !Node.IsEndOfToken && _fallbackStateCharacterCheck.CharacterIsValidForState(c) && _rootStates.TryGetState(c, out nextState))
+        if (StateLookup.TryGetState(c, out IState<TTokenType>? nextState) ||
+            !Node.IsEndOfToken && _fallbackStateCharacterCheck.CharacterIsValidForState(in c) &&
+            _rootStates.TryGetState(c, out nextState))
             return nextState;
 
         return _endOfTokenStateInstance;

--- a/Tokensharp/StateMachine/State.cs
+++ b/Tokensharp/StateMachine/State.cs
@@ -23,13 +23,9 @@ internal abstract class State<TTokenType> : IState<TTokenType> where TTokenType 
 
     protected abstract IState<TTokenType> DefaultState { get; }
 
-    public virtual bool FinalizeToken(ref StateMachineContext context, out int lexemeLength,
-        [NotNullWhen(true)] out TokenType<TTokenType>? tokenType)
-    {
-        lexemeLength = 0;
-        tokenType = null;
-        return false;
-    }
+    public virtual bool FinalizeToken(ref StateMachineContext context, [NotNullWhen(true)] ref TokenType<TTokenType>? tokenType,
+        ref int lexemeLength) =>
+        false;
 
     public virtual void UpdateCounts(ref StateMachineContext context)
     {

--- a/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
+++ b/Tokensharp/StateMachine/TextWhiteSpaceNumberBase.cs
@@ -20,7 +20,7 @@ internal abstract class TextWhiteSpaceNumberBase<TTokenType> : NodeStateBase<TTo
         if (StateLookup.TryGetState(in c, out IState<TTokenType>? nextState))
             return nextState;
 
-        if (CharacterIsValidForState(c))
+        if (CharacterIsValidForState(in c))
             return this;
         
         return _endOfTokenStateInstance;
@@ -39,8 +39,7 @@ internal abstract class TextWhiteSpaceNumberBase<TTokenType> : NodeStateBase<TTo
 
             if (startNode.IsEndOfToken)
             {
-                textWhiteSpaceNumberStates.Add(startNode.Character,
-                    EndOfTokenStateInstance);
+                textWhiteSpaceNumberStates.Add(startNode.Character, _endOfTokenStateInstance);
             }
             else
             {

--- a/Tokensharp/TokenParser.cs
+++ b/Tokensharp/TokenParser.cs
@@ -32,11 +32,14 @@ public readonly ref struct TokenParser<TTokenType>(TokenConfiguration<TTokenType
         IState<TTokenType>? currentState = _startState;
         var context = new StateMachineContext();
 
+        tokenType = null;
+        length = 0;
+
         foreach (char c in buffer)
         {
-            currentState = currentState.Transition(c, ref context);
-            if (currentState.IsEndOfToken)
-                return currentState.FinalizeToken(ref context, out length, out tokenType);
+            currentState = currentState.Transition(in c, ref context);
+            if (currentState.FinalizeToken(ref context, ref tokenType, ref length))
+                return true;
         }
 
         if (!moreDataAvailable)
@@ -47,6 +50,6 @@ public readonly ref struct TokenParser<TTokenType>(TokenConfiguration<TTokenType
             
         Debug.Assert(currentState is not null, "Default state transition resulted in null state");
             
-        return currentState.FinalizeToken(ref context, out length, out tokenType);
+        return currentState.FinalizeToken(ref context, ref tokenType, ref length);
     }
 }


### PR DESCRIPTION
Update `IState.FinalizeToken` signature, optimize loop, use Params for benchmarks, and improve method calls.