### PR TITLE
Add support for `@NumbersAreText` in token generator

### DIFF
--- a/Tokensharp.TokenTypeGenerator.Test/TestTokenTypes.json
+++ b/Tokensharp.TokenTypeGenerator.Test/TestTokenTypes.json
@@ -1,4 +1,5 @@
 ﻿{
+  "@NumbersAreText": true,
   "Hello": "World",
   "Foo": "Bar",
   "Fiz": "Buzz",

--- a/Tokensharp.TokenTypeGenerator.Test/Tokensharp.TokenTypeGenerator.Test.csproj
+++ b/Tokensharp.TokenTypeGenerator.Test/Tokensharp.TokenTypeGenerator.Test.csproj
@@ -6,6 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
+        <Version>1.0.0</Version>
     </PropertyGroup>
 
     <ItemGroup>
@@ -13,8 +14,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Tokensharp" Version="4.1.0" />
-      <PackageReference Include="Tokensharp.TokenTypeGenerator" Version="1.0.2" />
+      <ProjectReference Include="..\Tokensharp.TokenTypeGenerator\Tokensharp.TokenTypeGenerator.csproj" OutputItemType="Analyzer" />
+      <ProjectReference Include="..\Tokensharp\Tokensharp.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Tokensharp.TokenTypeGenerator/TokenDefinition.cs
+++ b/Tokensharp.TokenTypeGenerator/TokenDefinition.cs
@@ -4,10 +4,12 @@ internal readonly record struct TokenDefinition
 {
     public readonly string ClassName;
     public readonly IEnumerable<KeyValuePair<string, string>> Tokens;
+    public readonly bool NumbersAreText;
 
-    public TokenDefinition(string className, IEnumerable<KeyValuePair<string, string>> tokens)
+    public TokenDefinition(string className, IEnumerable<KeyValuePair<string, string>> tokens, bool numbersAreText)
     {
         ClassName = className;
         Tokens = tokens;
+        NumbersAreText = numbersAreText;
     }
 }

--- a/Tokensharp.TokenTypeGenerator/TokenTypeGenerator.cs
+++ b/Tokensharp.TokenTypeGenerator/TokenTypeGenerator.cs
@@ -56,11 +56,19 @@ namespace Tokensharp.TokenTypeGenerator
                 return null;
 
             var tokens = new Dictionary<string, string>();
-            JsonDocument jsonDocument = JsonDocument.Parse(sourceText.ToString());
-            foreach (JsonProperty property in jsonDocument.RootElement.EnumerateObject())
-                tokens.Add(property.Name, property.Value.GetString()!);
+            bool numbersAreText = false;
             
-            return new TokenDefinition(className, tokens);
+            JsonDocument jsonDocument = JsonDocument.Parse(sourceText.ToString());
+            
+            foreach (JsonProperty property in jsonDocument.RootElement.EnumerateObject())
+            {
+                if (property.NameEquals("@NumbersAreText"))
+                    numbersAreText = property.Value.GetBoolean();
+                else
+                    tokens.Add(property.Name, property.Value.GetString()!);
+            }
+            
+            return new TokenDefinition(className, tokens, numbersAreText);
         }
 
         private static TokenClassAndDefinition? LinkTokenClassToDefinition((TokenTypeClass Left, ImmutableArray<TokenDefinition> Right) classAndDefinitions, CancellationToken _)
@@ -90,12 +98,10 @@ namespace Tokensharp.TokenTypeGenerator
                                           
                                               public static {{className}} Create(string lexeme) => new(lexeme);
                                               
-                                              public static TokenConfiguration<{{className}}> Configuration { get; } = new TokenConfigurationBuilder<{{className}}>()
-                                              {
-                                                  {{
-                                                      string.Join(",\r\n            ", definition.TokenDefinition.Tokens.Select(def => def.Key))
-                                                  }}
-                                              }.Build();
+                                              public static TokenConfiguration<{{className}}> Configuration { get; } = new TokenConfigurationBuilder<{{className}}>(
+                                              [
+                                                  {{ string.Join(",\r\n            ", definition.TokenDefinition.Tokens.Select(def => def.Key)) }}
+                                              ]) { NumbersAreText = {{ (definition.TokenDefinition.NumbersAreText ? "true" : "false") }} }.Build();
                                           }
                                       }
                                       """;

--- a/Tokensharp.TokenTypeGenerator/Tokensharp.TokenTypeGenerator.csproj
+++ b/Tokensharp.TokenTypeGenerator/Tokensharp.TokenTypeGenerator.csproj
@@ -10,7 +10,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>1.0.2</Version>
+        <Version>1.1.0</Version>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>


### PR DESCRIPTION
### Summary

- Introduced a new `@NumbersAreText` property in `TokenTypeGenerator` to handle numbers as text during token parsing.
- Updated `TokenDefinition` and related logic for compatibility with the new property.
- Adjusted project references and tests to align with the changes.
- Incremented the version of `TokenTypeGenerator` to 1.1.0.