### PR TITLE
Update TokenTypeGenerator to version 1.2.0

### DIFF
--- a/Tokensharp.TokenTypeGenerator/Tokensharp.TokenTypeGenerator.csproj
+++ b/Tokensharp.TokenTypeGenerator/Tokensharp.TokenTypeGenerator.csproj
@@ -10,7 +10,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>1.1.0</Version>
+        <Version>1.2.0</Version>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>


### PR DESCRIPTION
Updated the TokenTypeGenerator dependency to version 1.2.0 due to 1.1.0 being deprecated on nuget repository.