### PR TITLE
Add support for `numbersAreText` property in token parsing

### DIFF
--- a/Tokensharp.TokenTypeGenerator.Test/TestTokenTypes.cs
+++ b/Tokensharp.TokenTypeGenerator.Test/TestTokenTypes.cs
@@ -1,4 +1,4 @@
 ﻿namespace Tokensharp.TokenTypeGenerator.Test;
 
-[TokenType]
+[TokenType(numbersAreText: true)]
 public partial record TestTokenTypes;

--- a/Tokensharp.TokenTypeGenerator.Test/TestTokenTypes.json
+++ b/Tokensharp.TokenTypeGenerator.Test/TestTokenTypes.json
@@ -1,5 +1,5 @@
 ﻿{
-  "@NumbersAreText": true,
+  "@NumbersAreText": false,
   "Hello": "World",
   "Foo": "Bar",
   "Fiz": "Buzz",

--- a/Tokensharp.TokenTypeGenerator/TokenTypeAttribute.cs
+++ b/Tokensharp.TokenTypeGenerator/TokenTypeAttribute.cs
@@ -1,4 +1,8 @@
 ﻿namespace Tokensharp.TokenTypeGenerator;
 
 [AttributeUsage(AttributeTargets.Class, Inherited = false)]
-public sealed class TokenTypeAttribute : Attribute;
+public sealed class TokenTypeAttribute(bool numbersAreText = false) : Attribute
+{
+    public bool NumbersAreText { get; } = numbersAreText;
+    public static readonly string FullName = typeof(TokenTypeAttribute).FullName!;
+}

--- a/Tokensharp.TokenTypeGenerator/TokenTypeClass.cs
+++ b/Tokensharp.TokenTypeGenerator/TokenTypeClass.cs
@@ -1,13 +1,15 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 
 namespace Tokensharp.TokenTypeGenerator;
 
 internal readonly record struct TokenTypeClass
 {
     public readonly ITypeSymbol TypeSymbol;
+    public readonly bool NumbersAreText;
 
-    public TokenTypeClass(ITypeSymbol typeSymbol)
+    public TokenTypeClass(ITypeSymbol typeSymbol, bool numbersAreText)
     {
         TypeSymbol = typeSymbol;
+        NumbersAreText = numbersAreText;
     }
 }

--- a/Tokensharp.TokenTypeGenerator/TokenTypeGenerator.cs
+++ b/Tokensharp.TokenTypeGenerator/TokenTypeGenerator.cs
@@ -9,7 +9,7 @@ namespace Tokensharp.TokenTypeGenerator
     [Generator(LanguageNames.CSharp)]
     public class TokenTypeGenerator : IIncrementalGenerator
     {
-        private static readonly string AttributeFullName = typeof(TokenTypeAttribute).FullName;
+        private static readonly string AttributeFullName = TokenTypeAttribute.FullName;
 
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
@@ -45,7 +45,14 @@ namespace Tokensharp.TokenTypeGenerator
             if (context.TargetSymbol is not ITypeSymbol symbol)
                 return null;
 
-            return new TokenTypeClass(symbol);
+            bool numbersAreText = false;
+            AttributeData? attribute = context.Attributes.FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == AttributeFullName);
+            if (attribute is { ConstructorArguments.Length: > 0 })
+            {
+                numbersAreText = (bool)attribute.ConstructorArguments[0].Value!;
+            }
+
+            return new TokenTypeClass(symbol, numbersAreText);
         }
 
         private static TokenDefinition? GetTokenDefinition(AdditionalText file, CancellationToken cancellationToken)
@@ -101,7 +108,7 @@ namespace Tokensharp.TokenTypeGenerator
                                               public static TokenConfiguration<{{className}}> Configuration { get; } = new TokenConfigurationBuilder<{{className}}>(
                                               [
                                                   {{ string.Join(",\r\n            ", definition.TokenDefinition.Tokens.Select(def => def.Key)) }}
-                                              ]) { NumbersAreText = {{ (definition.TokenDefinition.NumbersAreText ? "true" : "false") }} }.Build();
+                                              ]) { NumbersAreText = {{ (definition.TokenDefinition.NumbersAreText || definition.TokenClass.NumbersAreText ? "true" : "false") }} }.Build();
                                           }
                                       }
                                       """;

--- a/Tokensharp.TokenTypeGenerator/Tokensharp.TokenTypeGenerator.csproj
+++ b/Tokensharp.TokenTypeGenerator/Tokensharp.TokenTypeGenerator.csproj
@@ -10,7 +10,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>1.2.0</Version>
+        <Version>1.3.0</Version>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>


### PR DESCRIPTION
This pull request enhances the `TokenTypeGenerator` to add support for the `numbersAreText` property, allowing numeric values to be treated as text during token parsing. The following updates are included:

- Expanded `TokenTypeAttribute` and `TokenTypeClass` to incorporate the `numbersAreText` property.
- Updated token parsing logic to respect the `numbersAreText` setting in attributes and JSON configurations.
- Refactored and extended test cases to validate the new behavior.
- Incremented the library version to 1.3.0.